### PR TITLE
Release 0.7.7: harden sync and CLI UX

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        node: [22]
+        node: [20, 22]
 
     steps:
       - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.7] - 2026-02-07
+
+### Added
+
+- `agents status --fast` to skip external CLI probes for quicker status checks.
+- `agents doctor --fix-dry-run` to preview automatic fixes without mutating project files.
+- Sync lock handling for `.agents/generated/sync.lock` to guard against concurrent sync runs.
+- New shell-style argument tokenizer for interactive `agents mcp add` argument input.
+- New test suites:
+  - `tests/status.command.test.ts`
+  - `tests/sync-lock.integration.test.ts`
+  - `tests/shell-words.test.ts`
+
+### Changed
+
+- npm package publishing is now stricter and reproducible via:
+  - `prepack` build hook
+  - explicit `files` whitelist in `package.json`
+- CI matrix now validates Node.js `20` and `22` across Linux, macOS, and Windows.
+- Interactive `agents mcp add` now parses quoted/escaped args reliably instead of naive whitespace splitting.
+- README command reference updated for `status --fast` and `doctor --fix-dry-run`.
+- CLI version bumped to `0.7.7`.
+
+### Fixed
+
+- Reduced sync race conditions by introducing project-local sync lock acquisition before writes.
+- URL-based MCP import now uses timeout + retry behavior, improving resilience to transient network failures.
+
 ## [0.7.6] - 2026-02-05
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -62,8 +62,8 @@ agents connect [--path <dir>] [--llm codex,claude,gemini,copilot_vscode,cursor,a
 agents disconnect [--path <dir>] [--llm codex,claude,gemini,copilot_vscode,cursor,antigravity] [--interactive]
 agents sync [--path <dir>] [--check] [--verbose]
 agents watch [--path <dir>] [--interval <ms>] [--once] [--quiet]
-agents status [--path <dir>] [--json] [--verbose]
-agents doctor [--path <dir>] [--fix]
+agents status [--path <dir>] [--json] [--verbose] [--fast]
+agents doctor [--path <dir>] [--fix] [--fix-dry-run]
 agents reset [--path <dir>] [--local-only] [--hard]
 agents mcp list [--path <dir>] [--json]
 agents mcp add [name] [--path <dir>] [--transport stdio|http|sse] [--command <cmd>] [--arg <value>] [--url <url>] [--env KEY=VALUE] [--header KEY=VALUE] [--secret-env KEY=VALUE] [--secret-header KEY=VALUE] [--secret-arg index=value] [--target <integration>] [--replace]
@@ -73,7 +73,7 @@ agents mcp test [name] [--path <dir>] [--json] [--runtime] [--runtime-timeout-ms
 agents mcp doctor [name] [--path <dir>] [--json] [--runtime] [--runtime-timeout-ms <ms>]
 ```
 
-## MCP toolkit (0.7.6)
+## MCP toolkit (0.7.7)
 - `agents mcp add`: add one server via flags or interactive prompts; if `[name]` is an `http(s)` URL, it auto-runs import flow.
 - `agents mcp import`: import strict JSON/JSONC snippets (`--file`, `--json`, `--url`, or stdin).
 - Interactive import now prompts for template secret values (tokens/keys) and lets you skip with Enter; skipped values can be added later in `.agents/local.json`.
@@ -106,6 +106,8 @@ agents status --verbose
 ## Output UX
 - `agents status` prints a compact summary by default.
 - `agents status --verbose` prints full files/probes details.
+- `agents status --fast` skips external CLI probes for faster local checks.
+- `agents doctor --fix-dry-run` previews automatic fixes without mutating files.
 
 ## Project layout
 ```text

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agents-cli-dev",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agents-cli-dev",
-      "version": "0.7.6",
+      "version": "0.7.7",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,17 +1,27 @@
 {
   "name": "agents-cli-dev",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "description": "Onboarding-first CLI for AGENTS.md, MCP, and skills across LLM tools",
   "main": "dist/cli.js",
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "dev": "tsx src/cli.ts",
     "lint": "eslint .",
-    "test": "vitest run"
+    "test": "vitest run",
+    "prepack": "npm run build"
   },
   "bin": {
     "agents": "bin/agents"
   },
+  "files": [
+    "bin/",
+    "dist/",
+    "templates/",
+    "docs/",
+    "README.md",
+    "CHANGELOG.md",
+    "LICENSE"
+  ],
   "keywords": [
     "agents",
     "mcp",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -25,7 +25,7 @@ async function main(): Promise<void> {
   program
     .name('agents')
     .description('Onboarding-first CLI for AGENTS.md + MCP + skills across LLM coding tools')
-    .version('0.7.6')
+    .version('0.7.7')
 
   program
     .command('start')
@@ -121,11 +121,13 @@ async function main(): Promise<void> {
     .option('--path <dir>', 'Target project directory', process.cwd())
     .option('--json', 'Output machine-readable JSON', false)
     .option('--verbose', 'Show full files/probes breakdown', false)
-    .action(async (opts: { path: string; json: boolean; verbose: boolean }) => {
+    .option('--fast', 'Skip external CLI probes for quicker output', false)
+    .action(async (opts: { path: string; json: boolean; verbose: boolean; fast: boolean }) => {
       await runStatus({
         projectRoot: resolvePath(opts.path),
         json: Boolean(opts.json),
-        verbose: Boolean(opts.verbose)
+        verbose: Boolean(opts.verbose),
+        fast: Boolean(opts.fast)
       })
     })
 
@@ -134,10 +136,12 @@ async function main(): Promise<void> {
     .description('Validate setup and detect configuration problems')
     .option('--path <dir>', 'Target project directory', process.cwd())
     .option('--fix', 'Apply safe automatic fixes', false)
-    .action(async (opts: { path: string; fix: boolean }) => {
+    .option('--fix-dry-run', 'Preview what --fix would change without applying it', false)
+    .action(async (opts: { path: string; fix: boolean; fixDryRun: boolean }) => {
       await runDoctor({
         projectRoot: resolvePath(opts.path),
-        fix: Boolean(opts.fix)
+        fix: Boolean(opts.fix),
+        fixDryRun: Boolean(opts.fixDryRun)
       })
     })
 

--- a/src/commands/mcp-add.ts
+++ b/src/commands/mcp-add.ts
@@ -17,6 +17,7 @@ import {
 } from '../core/mcpValidation.js'
 import { performSync } from '../core/sync.js'
 import { formatWarnings } from '../core/warnings.js'
+import { parseShellWords } from '../core/shellWords.js'
 
 export interface McpAddOptions {
   projectRoot: string
@@ -95,9 +96,7 @@ export async function runMcpAdd(options: McpAddOptions): Promise<void> {
     }
     if (transport === 'stdio' && args.length === 0) {
       const raw = await promptOptionalText('Args (space-separated, optional)')
-      if (raw.trim().length > 0) {
-        args = raw.split(/\s+/).filter(Boolean)
-      }
+      args = parseShellWords(raw)
     }
   }
 

--- a/src/core/paths.ts
+++ b/src/core/paths.ts
@@ -19,6 +19,7 @@ export interface ProjectPaths {
   generatedCursorState: string
   generatedSkillsState: string
   generatedVscodeSettingsState: string
+  generatedSyncLock: string
   codexConfig: string
   geminiSettings: string
   vscodeMcp: string
@@ -60,6 +61,7 @@ export function getProjectPaths(projectRoot: string): ProjectPaths {
     generatedCursorState: path.join(generatedDir, 'cursor.state.json'),
     generatedSkillsState: path.join(generatedDir, 'skills.state.json'),
     generatedVscodeSettingsState: path.join(generatedDir, 'vscode.settings.state.json'),
+    generatedSyncLock: path.join(generatedDir, 'sync.lock'),
     codexConfig: path.join(root, '.codex', 'config.toml'),
     geminiSettings: path.join(root, '.gemini', 'settings.json'),
     vscodeMcp: path.join(root, '.vscode', 'mcp.json'),

--- a/src/core/shellWords.ts
+++ b/src/core/shellWords.ts
@@ -1,0 +1,90 @@
+export function parseShellWords(input: string): string[] {
+  const tokens: string[] = []
+  let current = ''
+  let hasToken = false
+  let inSingle = false
+  let inDouble = false
+  let escaping = false
+
+  const flush = (): void => {
+    if (!hasToken) return
+    tokens.push(current)
+    current = ''
+    hasToken = false
+  }
+
+  for (let i = 0; i < input.length; i += 1) {
+    const char = input[i] as string
+
+    if (escaping) {
+      current += char
+      hasToken = true
+      escaping = false
+      continue
+    }
+
+    if (inSingle) {
+      if (char === '\'') {
+        inSingle = false
+      } else {
+        current += char
+      }
+      hasToken = true
+      continue
+    }
+
+    if (inDouble) {
+      if (char === '"') {
+        inDouble = false
+      } else if (char === '\\') {
+        const next = input[i + 1]
+        if (next && ['\\', '"', '$', '`'].includes(next)) {
+          current += next
+          i += 1
+        } else {
+          current += char
+        }
+      } else {
+        current += char
+      }
+      hasToken = true
+      continue
+    }
+
+    if (/\s/.test(char)) {
+      flush()
+      continue
+    }
+
+    if (char === '\'') {
+      inSingle = true
+      hasToken = true
+      continue
+    }
+
+    if (char === '"') {
+      inDouble = true
+      hasToken = true
+      continue
+    }
+
+    if (char === '\\') {
+      escaping = true
+      hasToken = true
+      continue
+    }
+
+    current += char
+    hasToken = true
+  }
+
+  if (escaping) {
+    throw new Error('Invalid args: trailing escape character.')
+  }
+  if (inSingle || inDouble) {
+    throw new Error('Invalid args: unclosed quote.')
+  }
+
+  flush()
+  return tokens
+}

--- a/src/core/syncLock.ts
+++ b/src/core/syncLock.ts
@@ -1,0 +1,94 @@
+import { open, readFile, rm, stat } from 'node:fs/promises'
+import path from 'node:path'
+import { ensureDir } from './fs.js'
+
+const DEFAULT_STALE_MS = 5 * 60_000
+
+interface LockMetadata {
+  pid?: number
+  startedAt?: string
+}
+
+export async function acquireSyncLock(lockPath: string, staleMs = DEFAULT_STALE_MS): Promise<() => Promise<void>> {
+  await ensureDir(path.dirname(lockPath))
+
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    try {
+      const handle = await open(lockPath, 'wx')
+      try {
+        const metadata: LockMetadata = {
+          pid: process.pid,
+          startedAt: new Date().toISOString()
+        }
+        await handle.writeFile(`${JSON.stringify(metadata)}\n`, 'utf8')
+      } finally {
+        await handle.close()
+      }
+
+      return async (): Promise<void> => {
+        await rm(lockPath, { force: true })
+      }
+    } catch (error) {
+      const code = getErrorCode(error)
+      if (code !== 'EEXIST') {
+        throw error
+      }
+
+      const stale = await isLockStale(lockPath, staleMs)
+      if (stale) {
+        await rm(lockPath, { force: true })
+        continue
+      }
+
+      throw new Error(buildLockBusyMessage(lockPath, await readLockMetadata(lockPath)))
+    }
+  }
+
+  throw new Error(`Failed to acquire sync lock at ${lockPath}.`)
+}
+
+function buildLockBusyMessage(lockPath: string, metadata: LockMetadata | null): string {
+  if (!metadata) {
+    return `Another sync is already running for this project (${lockPath}). Try again in a few seconds.`
+  }
+
+  const parts: string[] = []
+  if (typeof metadata.pid === 'number') parts.push(`pid=${String(metadata.pid)}`)
+  if (typeof metadata.startedAt === 'string' && metadata.startedAt.trim().length > 0) {
+    parts.push(`startedAt=${metadata.startedAt}`)
+  }
+
+  if (parts.length === 0) {
+    return `Another sync is already running for this project (${lockPath}). Try again in a few seconds.`
+  }
+
+  return `Another sync is already running for this project (${lockPath}, ${parts.join(', ')}). Try again in a few seconds.`
+}
+
+async function isLockStale(lockPath: string, staleMs: number): Promise<boolean> {
+  try {
+    const info = await stat(lockPath)
+    const ageMs = Date.now() - info.mtimeMs
+    return ageMs > staleMs
+  } catch {
+    return true
+  }
+}
+
+async function readLockMetadata(lockPath: string): Promise<LockMetadata | null> {
+  try {
+    const raw = await readFile(lockPath, 'utf8')
+    const parsed = JSON.parse(raw) as LockMetadata
+    if (typeof parsed !== 'object' || parsed === null) return null
+    return parsed
+  } catch {
+    return null
+  }
+}
+
+function getErrorCode(value: unknown): string | undefined {
+  if (typeof value !== 'object' || value === null) return undefined
+  if (!('code' in value)) return undefined
+  const code = (value as { code?: unknown }).code
+  return typeof code === 'string' ? code : undefined
+}

--- a/tests/doctor.integration.test.ts
+++ b/tests/doctor.integration.test.ts
@@ -64,6 +64,21 @@ describe('doctor command', () => {
     expect(output).toContain('[error] MCP server "invalid" has invalid header key "Bad Header"')
     expect(process.exitCode).toBe(1)
   }, 15000)
+
+  it('supports fix dry-run without mutating files', async () => {
+    const projectRoot = await mkdtemp(path.join(os.tmpdir(), 'agents-doctor-'))
+    tempDirs.push(projectRoot)
+
+    await runInit({ projectRoot, force: true })
+
+    const output = await captureStdout(async () => {
+      await runDoctor({ projectRoot, fix: false, fixDryRun: true })
+    })
+
+    expect(output).toContain('Doctor fix dry-run:')
+    expect(output).toContain('Would run agents sync after fixes.')
+    expect(output).toContain('Next: run "agents doctor --fix" to apply these changes.')
+  }, 15000)
 })
 
 async function captureStdout(fn: () => Promise<void>): Promise<string> {

--- a/tests/shell-words.test.ts
+++ b/tests/shell-words.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+import { parseShellWords } from '../src/core/shellWords.js'
+
+describe('parseShellWords', () => {
+  it('parses unquoted args', () => {
+    expect(parseShellWords('npx -y @upstash/context7-mcp')).toEqual(['npx', '-y', '@upstash/context7-mcp'])
+  })
+
+  it('parses quoted args and escaped whitespace', () => {
+    expect(parseShellWords('node "my script.js" --name "Jane Doe" path\\ with\\ spaces')).toEqual([
+      'node',
+      'my script.js',
+      '--name',
+      'Jane Doe',
+      'path with spaces'
+    ])
+  })
+
+  it('supports empty quoted values', () => {
+    expect(parseShellWords('--token "" --label \'\'')).toEqual(['--token', '', '--label', ''])
+  })
+
+  it('throws for unclosed quotes', () => {
+    expect(() => parseShellWords('node "broken')).toThrow(/unclosed quote/i)
+  })
+
+  it('throws for dangling escape', () => {
+    expect(() => parseShellWords('node path\\')).toThrow(/trailing escape/i)
+  })
+})

--- a/tests/status.command.test.ts
+++ b/tests/status.command.test.ts
@@ -1,0 +1,62 @@
+import os from 'node:os'
+import path from 'node:path'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { runInit } from '../src/commands/init.js'
+import { runStatus } from '../src/commands/status.js'
+import { loadAgentsConfig, saveAgentsConfig } from '../src/core/config.js'
+import * as shell from '../src/core/shell.js'
+
+const tempDirs: string[] = []
+
+afterEach(async () => {
+  vi.restoreAllMocks()
+  for (const dir of tempDirs.splice(0, tempDirs.length)) {
+    await rm(dir, { recursive: true, force: true })
+  }
+})
+
+describe('status command', () => {
+  it('skips external probes in --fast mode', async () => {
+    const projectRoot = await mkdtemp(path.join(os.tmpdir(), 'agents-status-'))
+    tempDirs.push(projectRoot)
+
+    await runInit({ projectRoot, force: true })
+    const config = await loadAgentsConfig(projectRoot)
+    config.integrations.enabled = ['codex', 'claude', 'gemini', 'cursor', 'copilot_vscode', 'antigravity']
+    await saveAgentsConfig(projectRoot, config)
+
+    const runCommandSpy = vi.spyOn(shell, 'runCommand')
+    const commandExistsSpy = vi.spyOn(shell, 'commandExists')
+
+    const output = await captureStdout(async () => {
+      await runStatus({
+        projectRoot,
+        json: false,
+        verbose: false,
+        fast: true
+      })
+    })
+
+    expect(output).toContain('Probes: skipped (--fast)')
+    expect(runCommandSpy).not.toHaveBeenCalled()
+    expect(commandExistsSpy).not.toHaveBeenCalled()
+  })
+})
+
+async function captureStdout(fn: () => Promise<void>): Promise<string> {
+  const chunks: string[] = []
+  const originalWrite = process.stdout.write.bind(process.stdout)
+  ;(process.stdout.write as unknown as (chunk: string) => boolean) = ((chunk: string) => {
+    chunks.push(chunk)
+    return true
+  }) as unknown as typeof process.stdout.write
+
+  try {
+    await fn()
+  } finally {
+    ;(process.stdout.write as unknown as typeof process.stdout.write) = originalWrite as unknown as typeof process.stdout.write
+  }
+
+  return chunks.join('')
+}

--- a/tests/sync-lock.integration.test.ts
+++ b/tests/sync-lock.integration.test.ts
@@ -1,0 +1,56 @@
+import os from 'node:os'
+import path from 'node:path'
+import { mkdir, mkdtemp, rm, utimes, writeFile } from 'node:fs/promises'
+import { afterEach, describe, expect, it } from 'vitest'
+import { runInit } from '../src/commands/init.js'
+import { performSync } from '../src/core/sync.js'
+
+const tempDirs: string[] = []
+
+afterEach(async () => {
+  for (const dir of tempDirs.splice(0, tempDirs.length)) {
+    await rm(dir, { recursive: true, force: true })
+  }
+})
+
+describe('sync lock', () => {
+  it('fails when an active lock exists', async () => {
+    const projectRoot = await mkdtemp(path.join(os.tmpdir(), 'agents-sync-lock-'))
+    tempDirs.push(projectRoot)
+
+    await runInit({ projectRoot, force: true })
+    const generatedDir = path.join(projectRoot, '.agents', 'generated')
+    await mkdir(generatedDir, { recursive: true })
+    await writeFile(path.join(generatedDir, 'sync.lock'), `${JSON.stringify({ pid: 42, startedAt: new Date().toISOString() })}\n`, 'utf8')
+
+    await expect(
+      performSync({
+        projectRoot,
+        check: false,
+        verbose: false
+      }),
+    ).rejects.toThrow(/Another sync is already running/)
+  }, 15_000)
+
+  it('replaces stale lock files and continues', async () => {
+    const projectRoot = await mkdtemp(path.join(os.tmpdir(), 'agents-sync-lock-'))
+    tempDirs.push(projectRoot)
+
+    await runInit({ projectRoot, force: true })
+    const generatedDir = path.join(projectRoot, '.agents', 'generated')
+    const lockPath = path.join(generatedDir, 'sync.lock')
+    await mkdir(generatedDir, { recursive: true })
+    await writeFile(lockPath, `${JSON.stringify({ pid: 99, startedAt: '2000-01-01T00:00:00.000Z' })}\n`, 'utf8')
+
+    const staleAt = new Date(Date.now() - 10 * 60_000)
+    await utimes(lockPath, staleAt, staleAt)
+
+    const result = await performSync({
+      projectRoot,
+      check: false,
+      verbose: false
+    })
+
+    expect(result.changed.length).toBeGreaterThan(0)
+  }, 15_000)
+})


### PR DESCRIPTION
This PR releases v0.7.7 and includes production-readiness improvements across packaging, runtime robustness, and CLI usability. It adds sync locking, MCP URL import timeout/retry behavior, safer doctor flows with --fix-dry-run, and a fast status mode for local checks. It also improves interactive mcp add arg parsing and expands CI coverage to Node 20 and 22 while tightening npm publish contents. Validation was run with npm run build and npm test (77 passing tests).