### PR TITLE
release: 0.9.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@agents-dev/cli",
-  "version": "0.8.6",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@agents-dev/cli",
-      "version": "0.8.6",
+      "version": "0.9.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@clack/prompts": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-dev/cli",
-  "version": "0.8.6",
+  "version": "0.9.0",
   "description": "One config to rule them all — Practical standard layer for multi-LLM development. Sync MCP servers, skills, and AGENTS.md across Codex, Claude Code, Gemini CLI, Cursor, Copilot, Antigravity, Windsurf, and OpenCode.",
   "main": "dist/cli.js",
   "scripts": {


### PR DESCRIPTION
## Summary

Start the 0.9.0 line from current 0.8.6 state with a minimal placeholder commit.

## Changes

- bump package version to `0.9.0` in `package.json`
- bump lockfile package version to `0.9.0` in `package-lock.json`

This PR intentionally contains no feature changes yet.
