### PR TITLE
release: 0.8.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - No changes yet.
 
+## [0.8.7] - 2026-03-22
+
+### Fixed
+
+- Fixed `agents sync` dropping `cwd` from generated MCP configs for all tools (Codex, Gemini, VS Code, Cursor, Copilot, Antigravity, Windsurf, OpenCode). Closes #11.
+
 ## [0.8.6] - 2026-03-07
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.8.7] - 2026-03-22
 
+### Added
+
+- New integration: **Junie** (JetBrains) — MCP servers synced to `.junie/mcp/mcp.json`, skills bridged to `.junie/skills/`.
+
 ### Fixed
 
-- Fixed `agents sync` dropping `cwd` from generated MCP configs for all tools (Codex, Gemini, VS Code, Cursor, Copilot, Antigravity, Windsurf, OpenCode). Closes #11.
+- Fixed `agents sync` dropping `cwd` from generated MCP configs for all tools (Codex, Gemini, VS Code, Cursor, Copilot, Antigravity, Windsurf, OpenCode, Junie). Closes #11.
 
 ## [0.8.6] - 2026-03-07
 

--- a/README.md
+++ b/README.md
@@ -26,11 +26,11 @@
 
 Every AI coding tool wants its own config format:
 
-| | Codex | Claude | Gemini | Cursor | Copilot | Antigravity | Windsurf | OpenCode |
-|:--|:-----:|:------:|:------:|:------:|:-------:|:-----------:|:--------:|:--------:|
-| **Config** | `.codex/config.toml` | CLI commands | `.gemini/settings.json` | `.cursor/mcp.json` | `.vscode/mcp.json` | Global `mcp.json` | Global `mcp_config.json` | `opencode.json` |
-| **Instructions** | `AGENTS.md` | `CLAUDE.md` | `AGENTS.md` | `.cursorrules` | — | `AGENTS.md` | `AGENTS.md` | `AGENTS.md` |
-| **Format** | TOML | JSON (via CLI) | JSON | JSON | JSON | JSON | JSON | JSON |
+| | Codex | Claude | Gemini | Cursor | Copilot | Antigravity | Windsurf | OpenCode | Junie |
+|:--|:-----:|:------:|:------:|:------:|:-------:|:-----------:|:--------:|:--------:|:-----:|
+| **Config** | `.codex/config.toml` | CLI commands | `.gemini/settings.json` | `.cursor/mcp.json` | `.vscode/mcp.json` | Global `mcp.json` | Global `mcp_config.json` | `opencode.json` | `.junie/mcp/mcp.json` |
+| **Instructions** | `AGENTS.md` | `CLAUDE.md` | `AGENTS.md` | `.cursorrules` | — | `AGENTS.md` | `AGENTS.md` | `AGENTS.md` | `AGENTS.md` |
+| **Format** | TOML | JSON (via CLI) | JSON | JSON | JSON | JSON | JSON | JSON | JSON |
 
 > **Result:** Duplicated configs, team drift, painful onboarding.
 
@@ -148,6 +148,13 @@ Add a server once in `.agents/agents.json`, then run `agents sync` to materializ
     <td align="center">✅</td>
     <td>Writes project <code>opencode.json</code> (<code>mcp</code> block)</td>
   </tr>
+  <tr>
+    <td><strong>Junie</strong></td>
+    <td align="center">✅</td>
+    <td align="center">✅</td>
+    <td align="center">✅</td>
+    <td>Writes <code>.junie/mcp/mcp.json</code> + skills bridge <code>.junie/skills</code></td>
+  </tr>
 </table>
 
 ---
@@ -257,12 +264,15 @@ your-project/
 │                                        │          Global     │
 │                                        ├────────→ Windsurf   │
 │                                        │          Global MCP │
-│                                        └────────→ OpenCode   │
-│                                                   opencode.json │
+│                                        ├────────→ OpenCode   │
+│                                        │          opencode.json │
+│                                        └────────→ Junie      │
+│                                                   .junie/mcp/ │
 │                                                              │
 │   .agents/skills/ ── symlink ──→ .claude/skills              │
 │                                  .cursor/skills              │
 │                                  .gemini/skills              │
+│                                  .junie/skills               │
 │                                  .windsurf/skills            │
 └──────────────────────────────────────────────────────────────┘
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@agents-dev/cli",
-  "version": "0.8.6",
+  "version": "0.8.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@agents-dev/cli",
-      "version": "0.8.6",
+      "version": "0.8.7",
       "license": "Apache-2.0",
       "dependencies": {
         "@clack/prompts": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-dev/cli",
-  "version": "0.8.6",
+  "version": "0.8.7",
   "description": "One config to rule them all — Practical standard layer for multi-LLM development. Sync MCP servers, skills, and AGENTS.md across Codex, Claude Code, Gemini CLI, Cursor, Copilot, Antigravity, Windsurf, and OpenCode.",
   "main": "dist/cli.js",
   "scripts": {

--- a/src/commands/reset.ts
+++ b/src/commands/reset.ts
@@ -50,7 +50,8 @@ export async function runReset(options: ResetOptions): Promise<void> {
         paths.opencodeConfig,
         legacyAgentDir,
         paths.vscodeMcp,
-        paths.claudeDir
+        paths.claudeDir,
+        paths.junieDir
       ]
     : options.localOnly
       ? [
@@ -64,7 +65,9 @@ export async function runReset(options: ResetOptions): Promise<void> {
           legacyAgentDir,
           paths.vscodeMcp,
           paths.claudeSkillsBridge,
-          paths.cursorSkillsBridge
+          paths.cursorSkillsBridge,
+          paths.junieMcpDir,
+          paths.junieSkillsBridge
         ]
       : [
           paths.generatedDir,
@@ -78,7 +81,9 @@ export async function runReset(options: ResetOptions): Promise<void> {
           legacyAgentDir,
           paths.vscodeMcp,
           paths.claudeSkillsBridge,
-          paths.cursorSkillsBridge
+          paths.cursorSkillsBridge,
+          paths.junieMcpDir,
+          paths.junieSkillsBridge
         ]
 
   for (const target of targets) {

--- a/src/core/gitignore.ts
+++ b/src/core/gitignore.ts
@@ -14,7 +14,8 @@ const SOURCE_ONLY_ENTRIES = [
   '.antigravity/',
   '.windsurf/',
   '.opencode/',
-  'opencode.json'
+  'opencode.json',
+  '.junie/mcp/'
 ]
 
 export async function ensureProjectGitignore(projectRoot: string, syncMode: SyncMode): Promise<boolean> {

--- a/src/core/gitignore.ts
+++ b/src/core/gitignore.ts
@@ -15,7 +15,8 @@ const SOURCE_ONLY_ENTRIES = [
   '.windsurf/',
   '.opencode/',
   'opencode.json',
-  '.junie/mcp/'
+  '.junie/mcp/',
+  '.junie/skills'
 ]
 
 export async function ensureProjectGitignore(projectRoot: string, syncMode: SyncMode): Promise<boolean> {

--- a/src/core/mcp.ts
+++ b/src/core/mcp.ts
@@ -18,7 +18,8 @@ const ALL_INTEGRATIONS: IntegrationName[] = [
   'cursor',
   'antigravity',
   'windsurf',
-  'opencode'
+  'opencode',
+  'junie'
 ]
 const LEGACY_EXPAND_SETS: IntegrationName[][] = [
   ['codex', 'claude', 'gemini', 'copilot_vscode'],
@@ -66,7 +67,8 @@ export function resolveFromConfigAndLocal(input: {
     cursor: [],
     antigravity: [],
     windsurf: [],
-    opencode: []
+    opencode: [],
+    junie: []
   }
 
   const selectedServerNames: string[] = []

--- a/src/core/paths.ts
+++ b/src/core/paths.ts
@@ -39,6 +39,11 @@ export interface ProjectPaths {
   windsurfDir: string
   opencodeDir: string
   claudeDir: string
+  generatedJunie: string
+  junieDir: string
+  junieMcpDir: string
+  junieMcp: string
+  junieSkillsBridge: string
   geminiSkillsBridge: string
   claudeSkillsBridge: string
   cursorSkillsBridge: string
@@ -89,6 +94,11 @@ export function getProjectPaths(projectRoot: string): ProjectPaths {
     windsurfDir: path.join(root, '.windsurf'),
     opencodeDir: path.join(root, '.opencode'),
     claudeDir: path.join(root, '.claude'),
+    generatedJunie: path.join(generatedDir, 'junie.mcp.json'),
+    junieDir: path.join(root, '.junie'),
+    junieMcpDir: path.join(root, '.junie', 'mcp'),
+    junieMcp: path.join(root, '.junie', 'mcp', 'mcp.json'),
+    junieSkillsBridge: path.join(root, '.junie', 'skills'),
     geminiSkillsBridge: path.join(root, '.gemini', 'skills'),
     claudeSkillsBridge: path.join(root, '.claude', 'skills'),
     cursorSkillsBridge: path.join(root, '.cursor', 'skills'),

--- a/src/core/renderers.ts
+++ b/src/core/renderers.ts
@@ -218,3 +218,38 @@ export function renderOpencodeMcp(servers: ResolvedMcpServer[]): {
 
   return { mcp: out, warnings }
 }
+
+export function renderJunieMcp(servers: ResolvedMcpServer[]): {
+  mcpServers: Record<string, unknown>
+  warnings: string[]
+} {
+  const warnings: string[] = []
+  const out: Record<string, unknown> = {}
+
+  for (const server of servers) {
+    if (server.transport === 'stdio') {
+      if (!server.command) {
+        warnings.push(`Server "${server.name}" has no command; skipped in Junie output.`)
+        continue
+      }
+      out[server.name] = {
+        command: server.command,
+        args: server.args ?? [],
+        ...(server.cwd ? { cwd: server.cwd } : {}),
+        ...(server.env ? { env: server.env } : {})
+      }
+      continue
+    }
+
+    if (!server.url) {
+      warnings.push(`Server "${server.name}" has no url; skipped in Junie output.`)
+      continue
+    }
+    out[server.name] = {
+      url: server.url,
+      ...(server.headers ? { headers: server.headers } : {})
+    }
+  }
+
+  return { mcpServers: out, warnings }
+}

--- a/src/core/renderers.ts
+++ b/src/core/renderers.ts
@@ -30,6 +30,9 @@ export function renderCodexToml(servers: ResolvedMcpServer[]): RenderResult {
       lines.push(
         `args = [${(server.args ?? []).map((arg) => `"${escapeToml(arg)}"`).join(', ')}]`,
       )
+      if (server.cwd) {
+        lines.push(`cwd = "${escapeToml(server.cwd)}"`)
+      }
     } else {
       if (!server.url) {
         warnings.push(`Server "${server.name}" has no url; skipped in Codex output.`)
@@ -86,6 +89,7 @@ export function renderGeminiServers(servers: ResolvedMcpServer[]): {
         type: 'stdio',
         command: server.command,
         args: server.args ?? [],
+        ...(server.cwd ? { cwd: server.cwd } : {}),
         ...(server.env ? { env: server.env } : {})
       }
       continue
@@ -122,6 +126,7 @@ export function renderVscodeMcp(servers: ResolvedMcpServer[]): {
         type: 'stdio',
         command: server.command,
         args: server.args ?? [],
+        ...(server.cwd ? { cwd: server.cwd } : {}),
         ...(server.env ? { env: server.env } : {})
       }
       continue
@@ -157,6 +162,7 @@ export function renderWindsurfMcp(servers: ResolvedMcpServer[]): {
       out[server.name] = {
         command: server.command,
         args: server.args ?? [],
+        ...(server.cwd ? { cwd: server.cwd } : {}),
         ...(server.env ? { env: server.env } : {})
       }
       continue
@@ -192,6 +198,7 @@ export function renderOpencodeMcp(servers: ResolvedMcpServer[]): {
         type: 'local',
         enabled: true,
         command: [server.command, ...(server.args ?? [])],
+        ...(server.cwd ? { cwd: server.cwd } : {}),
         ...(server.env ? { environment: server.env } : {})
       }
       continue

--- a/src/core/skills.ts
+++ b/src/core/skills.ts
@@ -71,6 +71,18 @@ export async function syncSkills(args: {
     warnings
   })
 
+  await syncToolSkillsBridge({
+    enabled: enabledIntegrations.includes('junie') && hasSkills,
+    projectRoot,
+    parentDir: paths.junieDir,
+    bridgePath: paths.junieSkillsBridge,
+    sourcePath: paths.agentsSkillsDir,
+    label: '.junie/skills',
+    check,
+    changed,
+    warnings
+  })
+
   await cleanupLegacyAntigravityBridge({
     projectRoot,
     check,

--- a/src/integrations/junie.ts
+++ b/src/integrations/junie.ts
@@ -1,0 +1,13 @@
+import { renderJunieMcp } from '../core/renderers.js'
+import type { ResolvedMcpServer } from '../types.js'
+
+export function buildJuniePayload(servers: ResolvedMcpServer[]): {
+  payload: { mcpServers: Record<string, unknown> }
+  warnings: string[]
+} {
+  const rendered = renderJunieMcp(servers)
+  return {
+    payload: { mcpServers: rendered.mcpServers },
+    warnings: rendered.warnings
+  }
+}

--- a/src/integrations/registry.ts
+++ b/src/integrations/registry.ts
@@ -14,7 +14,8 @@ export const INTEGRATIONS: IntegrationDefinition[] = [
   { id: 'cursor', label: 'Cursor', requiredBinary: 'cursor-agent' },
   { id: 'antigravity', label: 'Antigravity', requiredBinary: 'antigravity' },
   { id: 'windsurf', label: 'Windsurf' },
-  { id: 'opencode', label: 'OpenCode' }
+  { id: 'opencode', label: 'OpenCode' },
+  { id: 'junie', label: 'Junie', requiredBinary: 'junie' }
 ]
 
 export const INTEGRATION_IDS: IntegrationName[] = INTEGRATIONS.map((item) => item.id)

--- a/src/integrations/syncHooks.ts
+++ b/src/integrations/syncHooks.ts
@@ -310,7 +310,9 @@ export const INTEGRATION_SYNC_HOOKS: IntegrationSyncHook[] = [
       }
     },
     materialize: async (context) => {
-      await ensureDir(context.paths.junieMcpDir)
+      if (!context.check) {
+        await ensureDir(context.paths.junieMcpDir)
+      }
       await writeManagedFile({
         absolutePath: context.paths.junieMcp,
         content: context.generatedByIntegration.junie ?? '{}',

--- a/src/integrations/syncHooks.ts
+++ b/src/integrations/syncHooks.ts
@@ -1,5 +1,5 @@
 import path from 'node:path'
-import { pathExists, readJson, removeIfExists } from '../core/fs.js'
+import { ensureDir, pathExists, readJson, removeIfExists } from '../core/fs.js'
 import { toChangedEntry, writeManagedFile } from '../core/managedFiles.js'
 import { getAntigravityGlobalMcpPath, normalizeAntigravityMcpPayload, readAntigravityMcp } from '../core/antigravity.js'
 import { getWindsurfGlobalMcpPath, normalizeWindsurfMcpPayload } from '../core/windsurf.js'
@@ -12,6 +12,7 @@ import { buildCursorPayload } from './cursor.js'
 import { buildGeminiPayload } from './gemini.js'
 import { buildOpencodePayload } from './opencode.js'
 import { buildWindsurfPayload } from './windsurf.js'
+import { buildJuniePayload } from './junie.js'
 import type { ProjectPaths } from '../core/paths.js'
 import type { AgentsConfig, IntegrationName, ResolvedMcpServer } from '../types.js'
 
@@ -292,6 +293,27 @@ export const INTEGRATION_SYNC_HOOKS: IntegrationSyncHook[] = [
       await writeManagedFile({
         absolutePath: targetPath,
         content: `${JSON.stringify(merged, null, 2)}\n`,
+        projectRoot: context.projectRoot,
+        check: context.check,
+        changed: context.changed
+      })
+    }
+  },
+  {
+    id: 'junie',
+    generatedPath: (paths) => paths.generatedJunie,
+    buildGenerated: (servers) => {
+      const junie = buildJuniePayload(servers)
+      return {
+        content: `${JSON.stringify(junie.payload, null, 2)}\n`,
+        warnings: junie.warnings
+      }
+    },
+    materialize: async (context) => {
+      await ensureDir(context.paths.junieMcpDir)
+      await writeManagedFile({
+        absolutePath: context.paths.junieMcp,
+        content: context.generatedByIntegration.junie ?? '{}',
         projectRoot: context.projectRoot,
         check: context.check,
         changed: context.changed

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,6 +9,7 @@ export type IntegrationName =
   | 'antigravity'
   | 'windsurf'
   | 'opencode'
+  | 'junie'
 export type SyncMode = 'source-only' | 'commit-generated'
 
 export type McpTransportType = 'stdio' | 'http' | 'sse'

--- a/tests/renderers.test.ts
+++ b/tests/renderers.test.ts
@@ -195,7 +195,7 @@ describe('renderers', () => {
 
     it('omits cwd when not set', () => {
       const codex = renderCodexToml(servers)
-      expect(codex.content).not.toContain('cwd')
+      expect(codex.content).not.toMatch(/^\s*cwd\s*=/m)
 
       const gemini = renderGeminiServers(servers)
       expect(gemini.mcpServers['filesystem']).not.toHaveProperty('cwd')

--- a/tests/renderers.test.ts
+++ b/tests/renderers.test.ts
@@ -3,6 +3,7 @@ import TOML from '@iarna/toml'
 import {
   renderCodexToml,
   renderGeminiServers,
+  renderJunieMcp,
   renderOpencodeMcp,
   renderVscodeMcp,
   renderWindsurfMcp
@@ -116,6 +117,22 @@ describe('renderers', () => {
     })
   })
 
+  it('renders junie mcp payload', () => {
+    const rendered = renderJunieMcp(servers)
+    expect(rendered.mcpServers).toMatchObject({
+      filesystem: {
+        command: 'npx'
+      },
+      'http-tools': {
+        url: 'https://example.com/mcp'
+      },
+      'sse-tools': {
+        url: 'https://example.com/sse'
+      }
+    })
+    expect(rendered.mcpServers['filesystem']).not.toHaveProperty('type')
+  })
+
   describe('cwd propagation', () => {
     const serversWithCwd: ResolvedMcpServer[] = [
       {
@@ -168,6 +185,14 @@ describe('renderers', () => {
       })
     })
 
+    it('junie includes cwd for stdio server', () => {
+      const rendered = renderJunieMcp(serversWithCwd)
+      expect(rendered.mcpServers['project-server']).toMatchObject({
+        command: 'pnpx',
+        cwd: '/abs/path/to/project'
+      })
+    })
+
     it('omits cwd when not set', () => {
       const codex = renderCodexToml(servers)
       expect(codex.content).not.toContain('cwd')
@@ -183,6 +208,9 @@ describe('renderers', () => {
 
       const opencode = renderOpencodeMcp(servers)
       expect(opencode.mcp['filesystem']).not.toHaveProperty('cwd')
+
+      const junie = renderJunieMcp(servers)
+      expect(junie.mcpServers['filesystem']).not.toHaveProperty('cwd')
     })
   })
 })

--- a/tests/renderers.test.ts
+++ b/tests/renderers.test.ts
@@ -115,4 +115,74 @@ describe('renderers', () => {
       }
     })
   })
+
+  describe('cwd propagation', () => {
+    const serversWithCwd: ResolvedMcpServer[] = [
+      {
+        name: 'project-server',
+        transport: 'stdio',
+        command: 'pnpx',
+        args: ['xcodebuildmcp@latest', 'mcp'],
+        cwd: '/abs/path/to/project'
+      }
+    ]
+
+    it('codex toml includes cwd for stdio server', () => {
+      const rendered = renderCodexToml(serversWithCwd)
+      expect(rendered.content).toContain('cwd = "/abs/path/to/project"')
+      expect(() => TOML.parse(rendered.content)).not.toThrow()
+    })
+
+    it('gemini includes cwd for stdio server', () => {
+      const rendered = renderGeminiServers(serversWithCwd)
+      expect(rendered.mcpServers['project-server']).toMatchObject({
+        type: 'stdio',
+        command: 'pnpx',
+        cwd: '/abs/path/to/project'
+      })
+    })
+
+    it('vscode includes cwd for stdio server', () => {
+      const rendered = renderVscodeMcp(serversWithCwd)
+      expect(rendered.servers['project-server']).toMatchObject({
+        type: 'stdio',
+        command: 'pnpx',
+        cwd: '/abs/path/to/project'
+      })
+    })
+
+    it('windsurf includes cwd for stdio server', () => {
+      const rendered = renderWindsurfMcp(serversWithCwd)
+      expect(rendered.mcpServers['project-server']).toMatchObject({
+        command: 'pnpx',
+        cwd: '/abs/path/to/project'
+      })
+    })
+
+    it('opencode includes cwd for stdio server', () => {
+      const rendered = renderOpencodeMcp(serversWithCwd)
+      expect(rendered.mcp['project-server']).toMatchObject({
+        type: 'local',
+        command: ['pnpx', 'xcodebuildmcp@latest', 'mcp'],
+        cwd: '/abs/path/to/project'
+      })
+    })
+
+    it('omits cwd when not set', () => {
+      const codex = renderCodexToml(servers)
+      expect(codex.content).not.toContain('cwd')
+
+      const gemini = renderGeminiServers(servers)
+      expect(gemini.mcpServers['filesystem']).not.toHaveProperty('cwd')
+
+      const vscode = renderVscodeMcp(servers)
+      expect(vscode.servers['filesystem']).not.toHaveProperty('cwd')
+
+      const windsurf = renderWindsurfMcp(servers)
+      expect(windsurf.mcpServers['filesystem']).not.toHaveProperty('cwd')
+
+      const opencode = renderOpencodeMcp(servers)
+      expect(opencode.mcp['filesystem']).not.toHaveProperty('cwd')
+    })
+  })
 })


### PR DESCRIPTION
## Summary

- **New integration: Junie (JetBrains)** — MCP servers synced to `.junie/mcp/mcp.json`, skills bridged to `.junie/skills/`, guidelines via `AGENTS.md`
- **Fix: `cwd` dropped from generated MCP configs** — all renderers now emit `cwd` for stdio servers (Codex, Gemini, VS Code, Cursor, Copilot, Antigravity, Windsurf, OpenCode, Junie)

Closes #11

## Test plan

- [x] `npm run build` passes
- [x] `npm test` — 159/159 tests pass (13 renderer tests including Junie + cwd propagation)
- [x] No regressions in existing integrations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Junie (JetBrains) integration with MCP server syncing and skills bridging support.

* **Bug Fixes**
  * agents sync now preserves working-directory (cwd) configuration for MCP servers across integrations.

* **Documentation**
  * Updated docs and diagrams to list Junie as a supported integration and show its generated outputs.

* **Tests**
  * Added tests covering Junie rendering and cwd propagation.

* **Chores**
  * Bumped release to 0.8.7 and updated changelog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->