### PR TITLE
feat: generate per-tool rule files from .agents/rules/

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,8 @@ your-project/
 │   ├── mcp_config.json              ← Generated Antigravity CLI MCP (gitignored in source-only mode)
 │   ├── skills/                      ← Reusable workflow definitions
 │   │   └── my-skill/SKILL.md
+│   ├── rules/                       ← Scoped instructions (→ per-tool rule files)
+│   │   └── my-rule.md
 │   └── generated/                   ← Auto-generated artifacts (gitignored)
 │       ├── codex.config.toml
 │       ├── claude-desktop.mcp.json
@@ -211,11 +213,47 @@ your-project/
 ├── .cursor/skills/ → .agents/skills  │
 ├── .gemini/skills/ → .agents/skills  │  Gemini workspace bridge
 ├── .windsurf/skills/ → .agents/skills│
-└── .junie/skills/ → .agents/skills   │
+├── .junie/skills/ → .agents/skills   │
+├── .cursor/rules/*.mdc               │  Rules generated from .agents/rules/
+├── .claude/rules/*.md                │
+├── .windsurf/rules/*.md              │
+└── .github/instructions/*.md         │  Copilot
 ```
 
-> **Git strategy:** By default only `.agents/agents.json`, `.agents/skills/`, and `AGENTS.md` are committed. Generated `CLAUDE.md` and tool-specific outputs are gitignored in source-only mode and regenerated with `agents sync`.
+> **Git strategy:** By default only `.agents/agents.json`, `.agents/skills/`, `.agents/rules/`, and `AGENTS.md` are committed. Generated `CLAUDE.md` and tool-specific outputs are gitignored in source-only mode and regenerated with `agents sync`.
 > Claude Desktop MCP is materialized into the user's global `claude_desktop_config.json`, not into the project tree.
+
+---
+
+## Rules
+
+Drop a markdown file in `.agents/rules/` and `agents sync` materializes it into the **native rule format** of every enabled tool that supports rule files — so a single scoped instruction stays aligned everywhere instead of being copied into four different formats by hand.
+
+Each rule declares its activation in YAML frontmatter:
+
+```markdown
+---
+description: API conventions
+globs: ["apps/api/**/*.ts"]   # file-scoped: only loads when matching files are in context
+alwaysApply: false            # set true for an always-on rule (omit globs)
+---
+
+All API endpoints must validate input with zod.
+```
+
+`agents sync` writes, for each enabled tool:
+
+| `.agents/rules/<name>.md` | Cursor `.cursor/rules/<name>.mdc` | Claude `.claude/rules/<name>.md` | Windsurf `.windsurf/rules/<name>.md` | Copilot `.github/instructions/<name>.instructions.md` |
+|---|---|---|---|---|
+| `alwaysApply: true` | `alwaysApply: true` | *(no `paths`)* | `trigger: always_on` | `applyTo: "**"` |
+| `globs: [...]` | `globs:` | `paths:` | `trigger: glob` + `globs:` | `applyTo:` |
+| `description` only | `description` | always-on* | `trigger: model_decision` | `applyTo: "**"`* |
+
+\* Claude and Copilot have no description/model-decision activation mode, so a description-only rule becomes always-on there (a warning is printed). Cursor and Windsurf support it natively.
+
+Stale rule files are removed automatically on the next sync (tracked in `.agents/generated/*.rules.state.json`). Rules are gated per tool — only enabled integrations get files.
+
+**Tools without a native rule-file mechanism** (Gemini, Codex, OpenCode, Junie, Antigravity) read your shared `AGENTS.md` directly, so put always-everywhere guidance there and use `.agents/rules/` for scoped/conditional instructions.
 
 ---
 
@@ -312,6 +350,7 @@ your-project/
 4. **Generate** — renders tool-specific config formats (TOML for Codex, JSON for others)
 5. **Materialize** — writes configs atomically (project-local and global targets), calls CLIs for Claude Code/Cursor, writes global configs with scoped merge/cleanup, and manages Claude Code's root `CLAUDE.md` wrapper
 6. **Bridge skills** — creates symlinks from tool directories to `.agents/skills/` where needed; Codex, Antigravity CLI, Copilot CLI, and OpenCode read `.agents/skills/` directly
+7. **Generate rules** — renders `.agents/rules/*.md` into each enabled tool's native rule format (Cursor/Claude/Windsurf/Copilot) and prunes stale rule files
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ All API endpoints must validate input with zod.
 
 `agents sync` writes, for each enabled tool:
 
-| `.agents/rules/<name>.md` | Cursor `.cursor/rules/<name>.mdc` | Claude `.claude/rules/<name>.md` | Windsurf `.windsurf/rules/<name>.md` | Copilot `.github/instructions/<name>.instructions.md` |
+| `.agents/rules/<name>.md` | Cursor `.cursor/rules/<name>.mdc` | Claude `.claude/rules/<name>.md` | Windsurf `.windsurf/rules/<name>.md` | GitHub Copilot `.github/instructions/<name>.instructions.md` |
 |---|---|---|---|---|
 | `alwaysApply: true` | `alwaysApply: true` | *(no `paths`)* | `trigger: always_on` | `applyTo: "**"` |
 | `globs: [...]` | `globs:` | `paths:` | `trigger: glob` + `globs:` | `applyTo:` |

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -155,6 +155,34 @@ agents sync
 
 ---
 
+## Scoped Rules
+
+Share one instruction across tools and have it load only where relevant.
+
+```bash
+mkdir -p .agents/rules
+cat > .agents/rules/api.md <<'EOF'
+---
+description: API conventions
+globs: ["apps/api/**/*.ts"]
+alwaysApply: false
+EOF
+# (close the frontmatter and add the rule body)
+printf -- '---\n\nAll API endpoints must validate input with zod.\n' >> .agents/rules/api.md
+
+agents sync
+```
+
+**Result** (for enabled tools):
+- Cursor → `.cursor/rules/api.mdc` (`globs: apps/api/**/*.ts`)
+- Claude Code → `.claude/rules/api.md` (`paths: ["apps/api/**/*.ts"]`)
+- Windsurf → `.windsurf/rules/api.md` (`trigger: glob`)
+- GitHub Copilot → `.github/instructions/api.instructions.md` (`applyTo: "apps/api/**/*.ts"`)
+
+Set `alwaysApply: true` (and omit `globs`) for an always-on rule. Tools without a native rule mechanism (Gemini, Codex, OpenCode, Junie, Antigravity) read `AGENTS.md` — keep always-everywhere guidance there.
+
+---
+
 ## Scripting
 
 ### Rotate MCP token daily

--- a/docs/agents-system.md
+++ b/docs/agents-system.md
@@ -23,6 +23,7 @@ Technical blueprint for advanced users.
 | `.agents/agents.json` | MCP servers (shared) |
 | `.agents/local.json` | Secrets (gitignored) |
 | `.agents/skills/` | Reusable workflows |
+| `.agents/rules/` | Scoped instructions (→ per-tool rule files) |
 
 ## Core Principles
 
@@ -43,6 +44,7 @@ project/
 │   ├── local.json              # Secrets (gitignored)
 │   ├── mcp_config.json         # Generated Antigravity CLI MCP
 │   ├── skills/                 # Workflows
+│   ├── rules/                  # Scoped instructions (→ per-tool rule files)
 │   └── generated/              # Auto-generated (gitignored)
 ├── .codex/                     # Materialized (gitignored)
 ├── .claude/                    # Materialized (gitignored)
@@ -137,6 +139,21 @@ project/
 
 **Validation:** `agents doctor` checks frontmatter (`name`, `description`)
 
+## Rules Sync
+
+`.agents/rules/*.md` declare activation in frontmatter (`alwaysApply` / `globs` / `description`) and are rendered into each enabled tool's native rule format:
+
+| Tool | Generated |
+|:-----|:----------|
+| **Cursor** | `.cursor/rules/<name>.mdc` (`alwaysApply` / `globs` / `description`) |
+| **Claude Code** | `.claude/rules/<name>.md` (`globs` → `paths`) |
+| **Windsurf** | `.windsurf/rules/<name>.md` (`trigger` / `globs` / `description`) |
+| **GitHub Copilot** | `.github/instructions/<name>.instructions.md` (`applyTo`) |
+
+- **Glob-scoped** rules load only when matching files are in context; **always-on** rules (`alwaysApply: true`) always load.
+- Tools without a native rule-file mechanism (Gemini, Codex, OpenCode, Junie, Antigravity) read `AGENTS.md` directly — put always-everywhere guidance there.
+- Generation is gated per enabled integration; stale rule files are pruned via `.agents/generated/*.rules.state.json`, and a pre-existing unmanaged rule file is never overwritten.
+
 ## Reset Options
 
 | Command | Effect |
@@ -203,6 +220,7 @@ project/
 **Committed:**
 - ✅ `.agents/agents.json`
 - ✅ `.agents/skills/`
+- ✅ `.agents/rules/`
 - ✅ `AGENTS.md`
 
 **Gitignored:**
@@ -212,6 +230,7 @@ project/
 - ❌ `.agents/mcp_config.json`
 - ❌ `.codex/`, `.claude/`, `.cursor/`, `.gemini/`
 - ❌ `.windsurf/`, `.opencode/`, `.junie/`, `.mcp.json`, `opencode.json`
+- ❌ `.claude/rules`, `.github/instructions` (generated rule files)
 - ❌ legacy `.antigravity/` (if present from older versions)
 
 ---

--- a/src/core/gitignore.ts
+++ b/src/core/gitignore.ts
@@ -12,6 +12,8 @@ const SOURCE_ONLY_ENTRIES = [
   '.mcp.json',
   '.vscode/mcp.json',
   '.claude/skills',
+  '.claude/rules',
+  '.github/instructions',
   '.cursor/',
   '.antigravity/',
   '.windsurf/',

--- a/src/core/paths.ts
+++ b/src/core/paths.ts
@@ -9,6 +9,7 @@ export interface ProjectPaths {
   rootClaudeMd: string
   agentsReadme: string
   agentsSkillsDir: string
+  agentsRulesDir: string
   generatedDir: string
   generatedCodex: string
   generatedGemini: string
@@ -26,6 +27,10 @@ export interface ProjectPaths {
   generatedClaudeState: string
   generatedClaudeInstructionsState: string
   generatedCursorState: string
+  generatedCursorRulesState: string
+  generatedClaudeRulesState: string
+  generatedWindsurfRulesState: string
+  generatedCopilotRulesState: string
   generatedSkillsState: string
   generatedVscodeSettingsState: string
   generatedSyncLock: string
@@ -55,6 +60,10 @@ export interface ProjectPaths {
   claudeSkillsBridge: string
   cursorSkillsBridge: string
   windsurfSkillsBridge: string
+  cursorRulesDir: string
+  claudeRulesDir: string
+  windsurfRulesDir: string
+  copilotInstructionsDir: string
 }
 
 /**
@@ -77,6 +86,7 @@ export function getProjectPaths(projectRoot: string): ProjectPaths {
     rootClaudeMd: path.join(root, 'CLAUDE.md'),
     agentsReadme: path.join(agentsDir, 'README.md'),
     agentsSkillsDir: path.join(agentsDir, 'skills'),
+    agentsRulesDir: path.join(agentsDir, 'rules'),
     generatedDir,
     generatedCodex: path.join(generatedDir, 'codex.config.toml'),
     generatedGemini: path.join(generatedDir, 'gemini.settings.json'),
@@ -94,6 +104,10 @@ export function getProjectPaths(projectRoot: string): ProjectPaths {
     generatedClaudeState: path.join(generatedDir, 'claude.state.json'),
     generatedClaudeInstructionsState: path.join(generatedDir, 'claude.instructions.state.json'),
     generatedCursorState: path.join(generatedDir, 'cursor.state.json'),
+    generatedCursorRulesState: path.join(generatedDir, 'cursor.rules.state.json'),
+    generatedClaudeRulesState: path.join(generatedDir, 'claude.rules.state.json'),
+    generatedWindsurfRulesState: path.join(generatedDir, 'windsurf.rules.state.json'),
+    generatedCopilotRulesState: path.join(generatedDir, 'copilot.rules.state.json'),
     generatedSkillsState: path.join(generatedDir, 'skills.state.json'),
     generatedVscodeSettingsState: path.join(generatedDir, 'vscode.settings.state.json'),
     generatedSyncLock: path.join(generatedDir, 'sync.lock'),
@@ -122,6 +136,10 @@ export function getProjectPaths(projectRoot: string): ProjectPaths {
     geminiSkillsBridge: path.join(root, '.gemini', 'skills'),
     claudeSkillsBridge: path.join(root, '.claude', 'skills'),
     cursorSkillsBridge: path.join(root, '.cursor', 'skills'),
-    windsurfSkillsBridge: path.join(root, '.windsurf', 'skills')
+    windsurfSkillsBridge: path.join(root, '.windsurf', 'skills'),
+    cursorRulesDir: path.join(root, '.cursor', 'rules'),
+    claudeRulesDir: path.join(root, '.claude', 'rules'),
+    windsurfRulesDir: path.join(root, '.windsurf', 'rules'),
+    copilotInstructionsDir: path.join(root, '.github', 'instructions')
   }
 }

--- a/src/core/project.ts
+++ b/src/core/project.ts
@@ -19,6 +19,7 @@ export async function initializeProjectSkeleton(args: {
   await ensureDir(paths.agentsDir)
   await ensureDir(paths.generatedDir)
   await ensureDir(paths.agentsSkillsDir)
+  await ensureDir(paths.agentsRulesDir)
 
   const changed: string[] = []
   const warnings: string[] = []

--- a/src/core/rules.ts
+++ b/src/core/rules.ts
@@ -131,7 +131,7 @@ async function discoverRules(rulesDir: string): Promise<RuleSource[]> {
     if (!entry.isFile()) continue
     if (entry.name.startsWith('.') || !entry.name.endsWith('.md')) continue
     const topic = entry.name.slice(0, -'.md'.length)
-    if (!topic) continue
+    if (!isSafeRuleName(topic)) continue
     const raw = await readFile(path.join(rulesDir, entry.name), 'utf8')
     rules.push({ topic, ...parseRuleFile(raw) })
   }
@@ -160,6 +160,11 @@ async function syncToolRules(args: {
 
   const toRemove = previous.filter((topic) => !desired.includes(topic))
   for (const topic of toRemove) {
+    // Defense-in-depth: never let a tampered state file drive deletion outside targetDir.
+    if (!isSafeRuleName(topic)) {
+      warnings.push(`Skipping invalid managed rule name in state: "${topic}"`)
+      continue
+    }
     const file = path.join(targetDir, `${topic}.${suffix}`)
     if (!(await pathExists(file))) continue
     changed.push(path.relative(projectRoot, file) || file)
@@ -338,12 +343,19 @@ function stripQuotes(value: string): string {
   return value.replace(/^["']|["']$/gu, '')
 }
 
+// A rule name (derived from a filename or read back from a state file) must be a
+// single safe path segment — no separators or traversal — before it is used to
+// build a file path for writing or deletion.
+function isSafeRuleName(name: string): boolean {
+  return name.length > 0 && !name.includes('/') && !name.includes('\\') && !name.includes('..')
+}
+
 async function readRulesState(statePath: string): Promise<string[]> {
   if (!(await pathExists(statePath))) return []
   try {
     const parsed = await readJson<RulesState>(statePath)
     return Array.isArray(parsed.managedNames)
-      ? parsed.managedNames.filter((name): name is string => typeof name === 'string')
+      ? parsed.managedNames.filter((name): name is string => typeof name === 'string' && isSafeRuleName(name))
       : []
   } catch {
     return []

--- a/src/core/rules.ts
+++ b/src/core/rules.ts
@@ -1,0 +1,366 @@
+import path from 'node:path'
+import { readdir, readFile } from 'node:fs/promises'
+import { ensureDir, pathExists, readJson, removeIfExists, writeJsonAtomic } from './fs.js'
+import { writeManagedFile } from './managedFiles.js'
+import { getProjectPaths } from './paths.js'
+import type { IntegrationName } from '../types.js'
+
+export interface RuleFrontmatter {
+  description?: string
+  globs?: string[]
+  alwaysApply?: boolean
+}
+
+export interface RuleSource {
+  topic: string
+  frontmatter: RuleFrontmatter
+  body: string
+}
+
+interface RulesState {
+  managedNames: string[]
+}
+
+interface RenderedRule {
+  topic: string
+  content: string
+}
+
+/**
+ * Synchronizes `.agents/rules/*.md` into per-tool rule files.
+ *
+ * Each source rule declares activation intent in YAML frontmatter
+ * (`alwaysApply`, `globs`, `description`). On sync it is rendered into the
+ * native rule format for every enabled tool that supports rule files:
+ *   - Cursor   -> `.cursor/rules/<topic>.mdc`               (alwaysApply / globs / description)
+ *   - Claude   -> `.claude/rules/<topic>.md`                (globs mapped to `paths`)
+ *   - Windsurf -> `.windsurf/rules/<topic>.md`              (trigger / globs / description)
+ *   - Copilot  -> `.github/instructions/<topic>.instructions.md` (applyTo)
+ * Stale rule files from previous syncs are removed via per-tool state files.
+ */
+export async function syncRules(args: {
+  projectRoot: string
+  enabledIntegrations: IntegrationName[]
+  check: boolean
+  changed: string[]
+  warnings: string[]
+}): Promise<void> {
+  const { projectRoot, enabledIntegrations, check, changed, warnings } = args
+  const paths = getProjectPaths(projectRoot)
+  const sources = await discoverRules(paths.agentsRulesDir)
+
+  const cursorEnabled = enabledIntegrations.includes('cursor')
+  const claudeEnabled = enabledIntegrations.includes('claude')
+  const windsurfEnabled = enabledIntegrations.includes('windsurf')
+  const copilotEnabled =
+    enabledIntegrations.includes('copilot_vscode') || enabledIntegrations.includes('copilot_cli')
+
+  // Warn once per source rule about activation modes a target can't express,
+  // and about commas inside globs that the comma-separated tool formats can't disambiguate.
+  for (const rule of sources) {
+    const globs = rule.frontmatter.globs ?? []
+    const descriptionOnly = globs.length === 0 && rule.frontmatter.alwaysApply !== true && Boolean(rule.frontmatter.description)
+    if (descriptionOnly && (claudeEnabled || copilotEnabled)) {
+      warnings.push(
+        `Rule "${rule.topic}" uses description-based activation, which Claude/Copilot rules cannot express; ` +
+          'they will load it as an always-on rule (Cursor and Windsurf keep the model-decision behavior).'
+      )
+    }
+    if ((cursorEnabled || windsurfEnabled) && globs.some((glob) => glob.includes(','))) {
+      warnings.push(
+        `Rule "${rule.topic}" has a glob containing a comma; Cursor/Windsurf use comma-separated globs and may misread it.`
+      )
+    }
+  }
+
+  await syncToolRules({
+    enabled: cursorEnabled,
+    targetDir: paths.cursorRulesDir,
+    suffix: 'mdc',
+    statePath: paths.generatedCursorRulesState,
+    rules: cursorEnabled ? sources.map((rule) => ({ topic: rule.topic, content: renderCursorRule(rule) })) : [],
+    projectRoot,
+    check,
+    changed,
+    warnings
+  })
+
+  await syncToolRules({
+    enabled: claudeEnabled,
+    targetDir: paths.claudeRulesDir,
+    suffix: 'md',
+    statePath: paths.generatedClaudeRulesState,
+    rules: claudeEnabled ? sources.map((rule) => ({ topic: rule.topic, content: renderClaudeRule(rule) })) : [],
+    projectRoot,
+    check,
+    changed,
+    warnings
+  })
+
+  await syncToolRules({
+    enabled: windsurfEnabled,
+    targetDir: paths.windsurfRulesDir,
+    suffix: 'md',
+    statePath: paths.generatedWindsurfRulesState,
+    rules: windsurfEnabled ? sources.map((rule) => ({ topic: rule.topic, content: renderWindsurfRule(rule, warnings) })) : [],
+    projectRoot,
+    check,
+    changed,
+    warnings
+  })
+
+  await syncToolRules({
+    enabled: copilotEnabled,
+    targetDir: paths.copilotInstructionsDir,
+    suffix: 'instructions.md',
+    statePath: paths.generatedCopilotRulesState,
+    rules: copilotEnabled ? sources.map((rule) => ({ topic: rule.topic, content: renderCopilotRule(rule) })) : [],
+    projectRoot,
+    check,
+    changed,
+    warnings
+  })
+}
+
+async function discoverRules(rulesDir: string): Promise<RuleSource[]> {
+  if (!(await pathExists(rulesDir))) return []
+  const entries = await readdir(rulesDir, { withFileTypes: true })
+  const rules: RuleSource[] = []
+
+  for (const entry of entries) {
+    if (!entry.isFile()) continue
+    if (entry.name.startsWith('.') || !entry.name.endsWith('.md')) continue
+    const topic = entry.name.slice(0, -'.md'.length)
+    if (!topic) continue
+    const raw = await readFile(path.join(rulesDir, entry.name), 'utf8')
+    rules.push({ topic, ...parseRuleFile(raw) })
+  }
+
+  rules.sort((a, b) => a.topic.localeCompare(b.topic))
+  return rules
+}
+
+async function syncToolRules(args: {
+  enabled: boolean
+  targetDir: string
+  suffix: string
+  statePath: string
+  rules: RenderedRule[]
+  projectRoot: string
+  check: boolean
+  changed: string[]
+  warnings: string[]
+}): Promise<void> {
+  const { enabled, targetDir, suffix, statePath, rules, projectRoot, check, changed, warnings } = args
+  const previous = await readRulesState(statePath)
+  const desired = enabled ? rules.map((rule) => rule.topic) : []
+
+  // Feature unused for this tool: nothing tracked, nothing to write.
+  if (previous.length === 0 && desired.length === 0) return
+
+  const toRemove = previous.filter((topic) => !desired.includes(topic))
+  for (const topic of toRemove) {
+    const file = path.join(targetDir, `${topic}.${suffix}`)
+    if (!(await pathExists(file))) continue
+    changed.push(path.relative(projectRoot, file) || file)
+    if (!check) await removeIfExists(file)
+  }
+
+  if (enabled && rules.length > 0 && !check) {
+    await ensureDir(targetDir)
+  }
+
+  const managed: string[] = []
+  for (const rule of rules) {
+    const file = path.join(targetDir, `${rule.topic}.${suffix}`)
+    // Never clobber a pre-existing rule file we did not create (parity with skills bridge).
+    if (!previous.includes(rule.topic) && (await pathExists(file))) {
+      warnings.push(
+        `Found existing ${path.relative(projectRoot, file) || file} not managed by agents; skipping to avoid overwriting it.`
+      )
+      continue
+    }
+    await writeManagedFile({ absolutePath: file, content: rule.content, projectRoot, check, changed })
+    managed.push(rule.topic)
+  }
+
+  // State is intentionally not written in check mode (dry run must not mutate).
+  if (!sameNames(previous, managed)) {
+    await writeRulesState(statePath, managed, check)
+  }
+}
+
+function renderCursorRule(rule: RuleSource): string {
+  const { description, globs, alwaysApply } = rule.frontmatter
+  const header = [
+    '---',
+    `description: ${description ? JSON.stringify(description) : ''}`,
+    `globs: ${(globs ?? []).join(',')}`,
+    `alwaysApply: ${alwaysApply === true}`,
+    '---'
+  ].join('\n')
+  return `${header}\n\n${rule.body.trimEnd()}\n`
+}
+
+// Claude Code reads `.claude/rules/<name>.md`; a `paths:` glob array makes the rule
+// load only when matching files are in context, and a file with no `paths` is always
+// loaded. See https://code.claude.com/docs/en/memory.md (path-specific rules).
+function renderClaudeRule(rule: RuleSource): string {
+  const globs = rule.frontmatter.globs ?? []
+  if (globs.length > 0) {
+    const list = globs.map((glob) => JSON.stringify(glob)).join(', ')
+    return `---\npaths: [${list}]\n---\n\n${rule.body.trimEnd()}\n`
+  }
+  // No globs -> always-loaded Claude rule (no frontmatter needed).
+  return `${rule.body.trimEnd()}\n`
+}
+
+const WINDSURF_CHAR_LIMIT = 6000
+
+function renderWindsurfRule(rule: RuleSource, warnings: string[]): string {
+  const { description, globs, alwaysApply } = rule.frontmatter
+  const header = ['---']
+
+  if (globs && globs.length > 0) {
+    header.push('trigger: glob')
+    header.push(`globs: ${globs.join(',')}`)
+  } else if (alwaysApply === true) {
+    header.push('trigger: always_on')
+  } else if (description) {
+    header.push('trigger: model_decision')
+  } else {
+    header.push('trigger: always_on')
+  }
+
+  // Windsurf requires a description on every rule; fall back to the topic name.
+  header.push(`description: ${JSON.stringify(description ?? rule.topic)}`)
+  header.push('---')
+
+  const content = `${header.join('\n')}\n\n${rule.body.trimEnd()}\n`
+  if (content.length > WINDSURF_CHAR_LIMIT) {
+    warnings.push(
+      `Rule "${rule.topic}" is ${content.length} chars, over Windsurf's ${WINDSURF_CHAR_LIMIT}-char per-rule limit; Windsurf may ignore the overflow.`
+    )
+  }
+  return content
+}
+
+function renderCopilotRule(rule: RuleSource): string {
+  const { description } = rule.frontmatter
+  const globs = rule.frontmatter.globs ?? []
+  const header = ['---', `applyTo: ${JSON.stringify(globs.length > 0 ? globs.join(',') : '**')}`]
+  if (description) {
+    header.push(`description: ${JSON.stringify(description)}`)
+  }
+  header.push('---')
+  return `${header.join('\n')}\n\n${rule.body.trimEnd()}\n`
+}
+
+function parseRuleFile(raw: string): { frontmatter: RuleFrontmatter; body: string } {
+  const match = raw.match(/^---\s*\n([\s\S]*?)\n---\s*\n?/u)
+  const frontmatter: RuleFrontmatter = {}
+  if (!match) {
+    return { frontmatter, body: raw.replace(/^\n+/, '') }
+  }
+
+  const body = raw.slice(match[0].length).replace(/^\n+/, '')
+  const lines = (match[1] ?? '').split('\n')
+
+  for (let i = 0; i < lines.length; i += 1) {
+    const trimmed = lines[i].trim()
+    if (!trimmed || trimmed.startsWith('#')) continue
+    const idx = trimmed.indexOf(':')
+    if (idx <= 0) continue
+    const key = trimmed.slice(0, idx).trim()
+    const value = trimmed.slice(idx + 1).trim()
+
+    if (key === 'description') {
+      frontmatter.description = stripQuotes(value)
+    } else if (key === 'alwaysApply') {
+      frontmatter.alwaysApply = value === 'true'
+    } else if (key === 'globs') {
+      if (value) {
+        frontmatter.globs = parseInlineList(value)
+      } else {
+        // YAML block list: collect the following indented "- item" lines.
+        const items: string[] = []
+        let j = i + 1
+        while (j < lines.length && /^\s*-\s+/u.test(lines[j])) {
+          items.push(stripQuotes(lines[j].replace(/^\s*-\s+/u, '').trim()))
+          j += 1
+        }
+        frontmatter.globs = items.filter(Boolean)
+        i = j - 1
+      }
+    }
+  }
+  return { frontmatter, body }
+}
+
+function parseInlineList(value: string): string[] {
+  const trimmed = value.trim()
+  if (trimmed.startsWith('[')) {
+    try {
+      const parsed: unknown = JSON.parse(trimmed)
+      if (Array.isArray(parsed)) {
+        return parsed.map((entry) => String(entry).trim()).filter(Boolean)
+      }
+    } catch {
+      // Not strict JSON (e.g. single quotes) — fall back to manual parsing.
+    }
+    return splitTopLevel(trimmed.replace(/^\[|\]$/gu, '')).map(stripQuotes).filter(Boolean)
+  }
+  return splitTopLevel(trimmed).map(stripQuotes).filter(Boolean)
+}
+
+// Split on commas that are not inside brace/bracket groups, so brace-expansion
+// globs like `src/{a,b}/**` stay intact.
+function splitTopLevel(input: string): string[] {
+  const out: string[] = []
+  let depth = 0
+  let current = ''
+  for (const char of input) {
+    if (char === '{' || char === '[') depth += 1
+    else if (char === '}' || char === ']') depth = Math.max(0, depth - 1)
+
+    if (char === ',' && depth === 0) {
+      out.push(current.trim())
+      current = ''
+    } else {
+      current += char
+    }
+  }
+  if (current.trim()) out.push(current.trim())
+  return out
+}
+
+function stripQuotes(value: string): string {
+  return value.replace(/^["']|["']$/gu, '')
+}
+
+async function readRulesState(statePath: string): Promise<string[]> {
+  if (!(await pathExists(statePath))) return []
+  try {
+    const parsed = await readJson<RulesState>(statePath)
+    return Array.isArray(parsed.managedNames)
+      ? parsed.managedNames.filter((name): name is string => typeof name === 'string')
+      : []
+  } catch {
+    return []
+  }
+}
+
+async function writeRulesState(statePath: string, names: string[], check: boolean): Promise<void> {
+  if (check) return
+  await ensureDir(path.dirname(statePath))
+  await writeJsonAtomic(statePath, {
+    managedNames: [...new Set(names)].sort((a, b) => a.localeCompare(b))
+  })
+}
+
+function sameNames(a: string[], b: string[]): boolean {
+  if (a.length !== b.length) return false
+  const sortedA = [...a].sort((x, y) => x.localeCompare(y))
+  const sortedB = [...b].sort((x, y) => x.localeCompare(y))
+  return sortedA.every((value, index) => value === sortedB[index])
+}

--- a/src/core/sync.ts
+++ b/src/core/sync.ts
@@ -10,6 +10,7 @@ import { toManagedClaudeName } from '../integrations/claude.js'
 import { INTEGRATION_SYNC_HOOKS } from '../integrations/syncHooks.js'
 import { ensureProjectGitignore } from './gitignore.js'
 import { syncSkills } from './skills.js'
+import { syncRules } from './rules.js'
 import { syncClaudeInstructions } from './claudeInstructions.js'
 import {
   getClaudeDesktopConfigPath,
@@ -145,6 +146,14 @@ export async function performSync(options: SyncOptions): Promise<SyncResult> {
     })
 
     await syncSkills({
+      projectRoot,
+      enabledIntegrations: config.integrations.enabled,
+      check,
+      changed,
+      warnings
+    })
+
+    await syncRules({
       projectRoot,
       enabledIntegrations: config.integrations.enabled,
       check,

--- a/tests/rules-sync.integration.test.ts
+++ b/tests/rules-sync.integration.test.ts
@@ -130,6 +130,23 @@ describe('rules sync', () => {
     expect(claude).toContain('Just guidance, no frontmatter.')
   })
 
+  it('warns and skips when an unmanaged rule file already exists', { timeout: 25000 }, async () => {
+    const projectRoot = await setupProject(['cursor'])
+
+    const cursorRulesDir = path.join(projectRoot, '.cursor', 'rules')
+    await mkdir(cursorRulesDir, { recursive: true })
+    await writeFile(path.join(cursorRulesDir, 'existing.mdc'), 'Unmanaged content.\n', 'utf8')
+
+    await writeRule(projectRoot, 'existing', '---\nalwaysApply: true\ndescription: x\n---\n\nNew rule.\n')
+
+    const result = await performSync({ projectRoot, check: false, verbose: false })
+
+    expect(result.warnings.some((w) => w.includes('not managed by agents'))).toBe(true)
+    // The pre-existing file is preserved, not overwritten.
+    const content = await readFile(path.join(cursorRulesDir, 'existing.mdc'), 'utf8')
+    expect(content).toBe('Unmanaged content.\n')
+  })
+
   it('removes stale rule files when the source rule is deleted', { timeout: 25000 }, async () => {
     const projectRoot = await setupProject(['cursor', 'claude'])
     await writeRule(

--- a/tests/rules-sync.integration.test.ts
+++ b/tests/rules-sync.integration.test.ts
@@ -1,0 +1,151 @@
+import os from 'node:os'
+import path from 'node:path'
+import { mkdir, mkdtemp, rm, readFile, writeFile } from 'node:fs/promises'
+import { afterEach, describe, expect, it } from 'vitest'
+import { runInit } from '../src/commands/init.js'
+import { loadAgentsConfig, saveAgentsConfig } from '../src/core/config.js'
+import type { IntegrationName } from '../src/types.js'
+import { pathExists } from '../src/core/fs.js'
+import { performSync } from '../src/core/sync.js'
+
+const tempDirs: string[] = []
+
+afterEach(async () => {
+  for (const dir of tempDirs.splice(0, tempDirs.length)) {
+    await rm(dir, { recursive: true, force: true })
+  }
+})
+
+async function setupProject(enabled: IntegrationName[]): Promise<string> {
+  const projectRoot = await mkdtemp(path.join(os.tmpdir(), 'agents-rules-sync-'))
+  tempDirs.push(projectRoot)
+  await runInit({ projectRoot, force: true })
+  const config = await loadAgentsConfig(projectRoot)
+  config.integrations.enabled = enabled
+  await saveAgentsConfig(projectRoot, config)
+  return projectRoot
+}
+
+async function writeRule(projectRoot: string, topic: string, content: string): Promise<void> {
+  const rulesDir = path.join(projectRoot, '.agents', 'rules')
+  await mkdir(rulesDir, { recursive: true })
+  await writeFile(path.join(rulesDir, `${topic}.md`), content, 'utf8')
+}
+
+describe('rules sync', () => {
+  it('renders a glob-scoped rule into each enabled tool format', { timeout: 25000 }, async () => {
+    const projectRoot = await setupProject(['cursor', 'claude', 'windsurf', 'copilot_vscode'])
+    await writeRule(
+      projectRoot,
+      'api',
+      '---\nglobs: ["apps/api/**/*.ts"]\ndescription: API rules\n---\n\nValidate all inputs.\n'
+    )
+
+    const check = await performSync({ projectRoot, check: true, verbose: false })
+    expect(check.changed).toContain('.cursor/rules/api.mdc')
+
+    await performSync({ projectRoot, check: false, verbose: false })
+
+    const cursor = await readFile(path.join(projectRoot, '.cursor', 'rules', 'api.mdc'), 'utf8')
+    expect(cursor).toContain('globs: apps/api/**/*.ts')
+    expect(cursor).toContain('alwaysApply: false')
+    expect(cursor).toContain('Validate all inputs.')
+
+    const claude = await readFile(path.join(projectRoot, '.claude', 'rules', 'api.md'), 'utf8')
+    expect(claude).toContain('paths: ["apps/api/**/*.ts"]')
+    expect(claude).toContain('Validate all inputs.')
+
+    const windsurf = await readFile(path.join(projectRoot, '.windsurf', 'rules', 'api.md'), 'utf8')
+    expect(windsurf).toContain('trigger: glob')
+    expect(windsurf).toContain('globs: apps/api/**/*.ts')
+
+    const copilot = await readFile(
+      path.join(projectRoot, '.github', 'instructions', 'api.instructions.md'),
+      'utf8'
+    )
+    expect(copilot).toContain('applyTo: "apps/api/**/*.ts"')
+  })
+
+  it('maps an always-on rule per tool and skips disabled tools', { timeout: 25000 }, async () => {
+    const projectRoot = await setupProject(['claude', 'windsurf'])
+    await writeRule(
+      projectRoot,
+      'house',
+      '---\nalwaysApply: true\ndescription: house rules\n---\n\nBe consistent.\n'
+    )
+
+    await performSync({ projectRoot, check: false, verbose: false })
+
+    const claude = await readFile(path.join(projectRoot, '.claude', 'rules', 'house.md'), 'utf8')
+    expect(claude).not.toContain('paths:')
+    expect(claude).toContain('Be consistent.')
+
+    const windsurf = await readFile(path.join(projectRoot, '.windsurf', 'rules', 'house.md'), 'utf8')
+    expect(windsurf).toContain('trigger: always_on')
+
+    // cursor + copilot are disabled -> no files generated
+    expect(await pathExists(path.join(projectRoot, '.cursor', 'rules', 'house.mdc'))).toBe(false)
+    expect(
+      await pathExists(path.join(projectRoot, '.github', 'instructions', 'house.instructions.md'))
+    ).toBe(false)
+  })
+
+  it('parses block-list globs, brace globs, and colon descriptions correctly', { timeout: 25000 }, async () => {
+    const projectRoot = await setupProject(['cursor', 'claude'])
+    await writeRule(
+      projectRoot,
+      'multi',
+      [
+        '---',
+        'description: "API: validation rules"',
+        'globs:',
+        '  - "apps/api/**/*.ts"',
+        '  - "src/{a,b}/**"',
+        '---',
+        '',
+        'Body.'
+      ].join('\n') + '\n'
+    )
+
+    await performSync({ projectRoot, check: false, verbose: false })
+
+    const claude = await readFile(path.join(projectRoot, '.claude', 'rules', 'multi.md'), 'utf8')
+    // Block-list globs are captured (not dropped) and the brace glob stays intact.
+    expect(claude).toContain('paths: ["apps/api/**/*.ts", "src/{a,b}/**"]')
+
+    const cursor = await readFile(path.join(projectRoot, '.cursor', 'rules', 'multi.mdc'), 'utf8')
+    expect(cursor).toContain('src/{a,b}/**')
+    // Description with a colon is quoted so it stays valid frontmatter.
+    expect(cursor).toContain('description: "API: validation rules"')
+  })
+
+  it('treats a rule with no frontmatter as an always-loaded Claude rule', { timeout: 25000 }, async () => {
+    const projectRoot = await setupProject(['claude'])
+    await writeRule(projectRoot, 'plain', 'Just guidance, no frontmatter.\n')
+
+    await performSync({ projectRoot, check: false, verbose: false })
+
+    const claude = await readFile(path.join(projectRoot, '.claude', 'rules', 'plain.md'), 'utf8')
+    expect(claude).not.toContain('---')
+    expect(claude).toContain('Just guidance, no frontmatter.')
+  })
+
+  it('removes stale rule files when the source rule is deleted', { timeout: 25000 }, async () => {
+    const projectRoot = await setupProject(['cursor', 'claude'])
+    await writeRule(
+      projectRoot,
+      'temp',
+      '---\nalwaysApply: true\ndescription: temporary\n---\n\nTemporary rule.\n'
+    )
+
+    await performSync({ projectRoot, check: false, verbose: false })
+    expect(await pathExists(path.join(projectRoot, '.cursor', 'rules', 'temp.mdc'))).toBe(true)
+    expect(await pathExists(path.join(projectRoot, '.claude', 'rules', 'temp.md'))).toBe(true)
+
+    await rm(path.join(projectRoot, '.agents', 'rules', 'temp.md'))
+    await performSync({ projectRoot, check: false, verbose: false })
+
+    expect(await pathExists(path.join(projectRoot, '.cursor', 'rules', 'temp.mdc'))).toBe(false)
+    expect(await pathExists(path.join(projectRoot, '.claude', 'rules', 'temp.md'))).toBe(false)
+  })
+})


### PR DESCRIPTION
## What

Adds a `.agents/rules/<topic>.md` source folder that `agents sync` materializes into the **native rule format** of every enabled tool that supports rule files — so one scoped instruction stays aligned everywhere instead of being hand-copied into each tool's format.

| `.agents/rules/<name>.md` | Cursor | Claude | Windsurf | Copilot |
|---|---|---|---|---|
| `alwaysApply: true` | `.cursor/rules/<name>.mdc` `alwaysApply: true` | `.claude/rules/<name>.md` *(no `paths`)* | `.windsurf/rules/<name>.md` `trigger: always_on` | `.github/instructions/<name>.instructions.md` `applyTo: "**"` |
| `globs: [...]` | `globs:` | `paths:` | `trigger: glob` + `globs:` | `applyTo:` |
| `description` only | `description` | always-on* | `trigger: model_decision` | `applyTo: "**"`* |

\* Claude and Copilot have no description/model-decision activation mode, so a description-only rule loads as always-on there (a warning is printed). Cursor and Windsurf keep the model-decision behavior natively.

Example source rule:

```markdown
---
description: API conventions
globs: ["apps/api/**/*.ts"]
alwaysApply: false
---

All API endpoints must validate input with zod.
```

## How it fits the existing design

- **Auto-discovered** by scanning `.agents/rules/` — no `agents.json` entry, mirroring how skills work.
- Rules need **per-tool frontmatter transformation** (e.g. Cursor `globs` ↔ Claude `paths`), so unlike skills (symlinked) they're generate-and-write via `writeManagedFile`.
- **Stale rule files are pruned** on the next sync using per-tool state files (`.agents/generated/*.rules.state.json`), following the same pattern as the MCP/state sync.
- **Gated per enabled integration** — disabling a tool cleans up its previously-managed rules; an existing unmanaged rule file is never overwritten (warn + skip, parity with the skills bridge).
- Frontmatter parsing handles inline arrays, comma lists, and YAML block lists, and keeps brace-expansion globs (`src/{a,b}/**`) intact.
- Source-only gitignore updated (`.claude/rules`, `.github/instructions`).

## Scope

Targets the four tools with a native per-rule-file mechanism: **Cursor, Claude, Windsurf, Copilot**. Tools without one (Gemini, Codex, OpenCode, Junie, Antigravity) read `AGENTS.md` directly and are unaffected.

References for the generated formats: [Cursor rules](https://cursor.com/docs/rules), [Claude path-specific rules](https://code.claude.com/docs/en/memory.md), [Windsurf rules](https://docs.windsurf.com/windsurf/cascade/rules), [Copilot custom instructions](https://docs.github.com/copilot/customizing-copilot/adding-custom-instructions-for-github-copilot).

## Testing

`tests/rules-sync.integration.test.ts` covers per-tool mapping (glob + always-on), disabled-tool skipping, stale cleanup, YAML block-list / brace-glob / colon-description parsing, and no-frontmatter rules. `npm run build`, `npm run lint`, and the existing `test:fast` suite (114 tests) all pass.

## Open question / possible follow-up

Should rule-less tools (Gemini, Codex, OpenCode, Junie, Antigravity) be able to receive **always-on** rules too? I deliberately left this out because:

- those tools have no lazy/glob loading, so importing scoped rules would always-load them → context bloat, defeating the purpose;
- file-inclusion isn't uniform — Gemini has `@file.md`, but `AGENTS.md` (Codex/OpenCode/Junie/Antigravity) has no import spec;
- genuinely-universal content already belongs in `AGENTS.md`, which all of them read.

A clean future option would be an **opt-in per-rule flag** that surfaces an always-on rule into the instructions file (or Gemini's native `@import`) for those tools, keeping default behavior unchanged. Happy to follow up if that's of interest — wanted to keep this PR focused first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Новые возможности**
  * Добавлена синхронизация scoped-правил агентов в нативные форматы для Cursor, Claude, Windsurf и GitHub Copilot с генерацией и автоматическим удалением устаревших файлов.

* **Документация**
  * Обновлён README и справочная документация: каталог правил, формат frontmatter, поведение при генерации для разных интеграций и примеры использования.

* **Тесты**
  * Добавлен интеграционный тест для верификации генерации, поведения при конфликтах и pruning устаревших артефактов.

* **Прочее**
  * Расширены правила игнорирования и инициализация проекта для поддержки каталога правил.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->