### PR TITLE
Preserve unmanaged Codex project settings during sync

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,6 +117,7 @@ Each tool has a renderer that converts `.agents/agents.json` to tool-specific fo
 - **Cursor:** JSON (`.cursor/mcp.json`)
 - **Copilot:** JSON (`.vscode/mcp.json`)
 - **Antigravity:** JSON (`.antigravity/mcp.json`)
+- **Hermes Agent:** YAML (`~/.hermes/config.yaml` or one named profile selected per workspace)
 
 ### 4. MCP Server Management (`core/mcp.ts`)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- No changes yet.
+### Added
+
+- New integration: **Hermes Agent** (`hermes`) — each workspace targets one Hermes home or named profile through `integrations.options.hermesProfile`; MCP servers are merged into native YAML while preserving unmanaged settings and entries.
+- Hermes sync supports managed ownership cleanup, dry-run drift checks, status reporting, and YAML diagnostics.
 
 ## [0.8.9] - 2026-05-31
 

--- a/README.md
+++ b/README.md
@@ -26,11 +26,11 @@
 
 Every AI coding tool wants its own config format:
 
-| | Codex | Claude Code | Claude Desktop | Gemini | Cursor | Copilot VS Code | Copilot CLI | Antigravity | Windsurf | OpenCode | Junie |
-|:--|:-----:|:-----------:|:---------------:|:------:|:------:|:---------------:|:-----------:|:-----------:|:--------:|:--------:|:-----:|
-| **Config** | `.codex/config.toml` | CLI commands | Global `claude_desktop_config.json` | `.gemini/settings.json` | `.cursor/mcp.json` | `.vscode/mcp.json` | `.mcp.json` | `.agents/mcp_config.json` | Global `mcp_config.json` | `opencode.json` | `.junie/mcp/mcp.json` |
-| **Instructions** | `AGENTS.md` | `CLAUDE.md` | — | `AGENTS.md` | `.cursorrules` | — | `AGENTS.md` | `AGENTS.md` | `AGENTS.md` | `AGENTS.md` | `AGENTS.md` |
-| **Format** | TOML | JSON (via CLI) | JSON | JSON | JSON | JSON | JSON | JSON | JSON | JSON | JSON |
+| | Codex | Claude Code | Claude Desktop | Gemini | Cursor | Copilot VS Code | Copilot CLI | Antigravity | Windsurf | OpenCode | Junie | Hermes |
+|:--|:-----:|:-----------:|:---------------:|:------:|:------:|:---------------:|:-----------:|:-----------:|:--------:|:--------:|:-----:|:------:|
+| **Config** | `.codex/config.toml` | CLI commands | Global `claude_desktop_config.json` | `.gemini/settings.json` | `.cursor/mcp.json` | `.vscode/mcp.json` | `.mcp.json` | `.agents/mcp_config.json` | Global `mcp_config.json` | `opencode.json` | `.junie/mcp/mcp.json` | One home/profile `config.yaml` |
+| **Instructions** | `AGENTS.md` | `CLAUDE.md` | — | `AGENTS.md` | `.cursorrules` | — | `AGENTS.md` | `AGENTS.md` | `AGENTS.md` | `AGENTS.md` | `AGENTS.md` | — |
+| **Format** | TOML | JSON (via CLI) | JSON | JSON | JSON | JSON | JSON | JSON | JSON | JSON | JSON | YAML |
 
 > **Result:** Duplicated configs, team drift, painful onboarding.
 
@@ -170,6 +170,13 @@ Add a server once in `.agents/agents.json`, then run `agents sync` to materializ
     <td align="center">✅</td>
     <td>Writes <code>.junie/mcp/mcp.json</code> + skills bridge <code>.junie/skills</code></td>
   </tr>
+  <tr>
+    <td><strong>Hermes Agent</strong></td>
+    <td align="center">✅</td>
+    <td align="center">—</td>
+    <td align="center">—</td>
+    <td>Merges into one active home or named profile <code>config.yaml</code>; preserves unmanaged YAML and cleans only workspace-owned servers</td>
+  </tr>
 </table>
 
 Antigravity note: `agents` manages the workspace MCP config used by Antigravity CLI. Global Antigravity editor/CLI profile files are left user-owned, and product limitations such as current Google/Google Cloud remote MCP OAuth caveats still apply.
@@ -195,6 +202,7 @@ your-project/
 │       ├── gemini.settings.json
 │       ├── antigravity.mcp_config.json
 │       ├── cursor.mcp.json
+│       ├── hermes.mcp.json
 │       ├── windsurf.mcp.json
 │       ├── opencode.json
 │       └── ...
@@ -216,6 +224,7 @@ your-project/
 
 > **Git strategy:** By default only `.agents/agents.json`, `.agents/skills/`, and `AGENTS.md` are committed. Generated `CLAUDE.md` and tool-specific outputs are gitignored in source-only mode and regenerated with `agents sync`.
 > Claude Desktop MCP is materialized into the user's global `claude_desktop_config.json`, not into the project tree.
+> Hermes MCP is materialized into exactly one home or named profile per workspace. Multiple workspaces may share a Hermes process while retaining independent profile configuration.
 
 ---
 
@@ -309,7 +318,7 @@ your-project/
 1. **Load** — reads `.agents/agents.json` + merges secrets from `.agents/local.json`
 2. **Resolve** — expands `${PROJECT_ROOT}`, `${ENV_VAR}` placeholders, filters by `enabled` and `requiredEnv`
 3. **Route** — sends each server to its target integrations (or all, if no `targets` specified)
-4. **Generate** — renders tool-specific config formats (TOML for Codex, JSON for others)
+4. **Generate** — renders tool-specific config formats (TOML for Codex, YAML for Hermes, JSON for others)
 5. **Materialize** — writes configs atomically (project-local and global targets), calls CLIs for Claude Code/Cursor, writes global configs with scoped merge/cleanup, and manages Claude Code's root `CLAUDE.md` wrapper
 6. **Bridge skills** — creates symlinks from tool directories to `.agents/skills/` where needed; Codex, Antigravity CLI, Copilot CLI, and OpenCode read `.agents/skills/` directly
 

--- a/docs/agents-system.md
+++ b/docs/agents-system.md
@@ -77,6 +77,7 @@ project/
 | **Windsurf** | Global user profile `~/.codeium/windsurf/mcp_config.json` (preserves unmanaged entries) |
 | **OpenCode** | `opencode.json` (`mcp` block) |
 | **Junie** | `.junie/mcp/mcp.json` |
+| **Hermes Agent** | `~/.hermes/config.yaml`, or one named profile via `integrations.options.hermesProfile` |
 
 ## Claude Instructions
 

--- a/docs/plans/2026-07-14-hermes-integration.md
+++ b/docs/plans/2026-07-14-hermes-integration.md
@@ -1,0 +1,109 @@
+# Hermes Integration Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add Hermes Agent as a first-class Agent Sync MCP target while keeping every workspace mapped to exactly one independent Hermes home or profile.
+
+**Architecture:** Agent Sync renders its resolved MCP registry into Hermes' native `mcp_servers` YAML shape. Each workspace selects one target with `integrations.options.hermesProfile` (or the active `HERMES_HOME` when null). A Hermes sync hook merges only that workspace's owned servers, preserves unmanaged YAML, tracks ownership in `.agents/generated/hermes.state.json`, cleans the previous target when retargeted, and supports dry-run drift detection. There is no cross-profile fan-out.
+
+**Tech Stack:** TypeScript, Vitest, Node.js filesystem APIs, `yaml` for comment-preserving YAML document updates.
+
+---
+
+### Task 1: Register Hermes as an integration
+
+**Files:**
+- Modify: `src/types.ts`
+- Modify: `src/integrations/registry.ts`
+- Modify: `src/core/config.ts`
+- Modify: `tests/config.test.ts`
+
+**Steps:**
+1. Add failing tests proving `hermes` is accepted as an integration and `hermesProfile` defaults to `null` while surviving config reload.
+2. Run `npm test -- tests/config.test.ts tests/mcp-validation.test.ts` and confirm the tests fail because Hermes is unknown.
+3. Add `hermes` to `IntegrationName`, `INTEGRATIONS`, and default MCP targets; add `hermesProfile` to normalized integration options.
+4. Re-run the focused tests and confirm they pass.
+
+### Task 2: Render Hermes-native MCP definitions
+
+**Files:**
+- Create: `src/integrations/hermes.ts`
+- Modify: `tests/renderers.test.ts`
+
+**Steps:**
+1. Add failing renderer tests for stdio, Streamable HTTP, and SSE definitions, including headers, environment variables, and `enabled: true`.
+2. Run `npm test -- tests/renderers.test.ts` and confirm the missing renderer failure.
+3. Implement `buildHermesPayload()` with Hermes-native keys and a warning when a stdio `cwd` cannot be represented.
+4. Re-run the renderer tests and confirm they pass.
+
+### Task 3: Merge managed servers into Hermes YAML safely
+
+**Files:**
+- Create: `src/core/hermes.ts`
+- Create: `tests/hermes.test.ts`
+- Modify: `package.json`
+- Modify: `package-lock.json`
+
+**Steps:**
+1. Add `yaml` as a runtime dependency.
+2. Add failing tests proving the merge preserves comments, unrelated settings, unmanaged MCP servers, and platform-specific `no_mcp`; replaces current managed servers; and removes stale managed entries.
+3. Add failing tests for default-home resolution, one named profile, unsafe profile rejection, and the singular `AGENTS_HERMES_CONFIG_PATH` test/operator override.
+4. Run `npm test -- tests/hermes.test.ts` and confirm the failures.
+5. Implement config discovery, YAML merge, managed-state parsing, and atomic writes using existing filesystem helpers.
+6. Re-run the focused tests and confirm they pass.
+
+### Task 4: Wire Hermes into sync and check mode
+
+**Files:**
+- Modify: `src/core/paths.ts`
+- Modify: `src/integrations/syncHooks.ts`
+- Create: `tests/hermes-sync.integration.test.ts`
+
+**Steps:**
+1. Add failing integration tests proving normal sync updates one selected config, `--check` reports drift without writing, retargeting cleans the previous config, and disabling Hermes removes only previously managed entries.
+2. Run `npm test -- tests/hermes-sync.integration.test.ts` and confirm the failures.
+3. Add generated payload/state paths and a Hermes sync hook with `materializeWhenDisabled` cleanup semantics.
+4. Re-run the focused integration tests and confirm they pass.
+
+### Task 5: Complete CLI visibility and documentation
+
+**Files:**
+- Modify: `src/commands/status.ts`
+- Modify: `src/commands/doctor.ts`
+- Modify: `README.md`
+- Modify: `CHANGELOG.md`
+- Modify: `package.json`
+- Modify: `AGENTS.md`
+
+**Steps:**
+1. Add status/doctor assertions that Hermes is visible and its config targets are reported.
+2. Update the supported-integration table, package description and keywords, development guide, and Unreleased changelog.
+3. Run focused status/doctor tests.
+
+### Task 6: Verify and export the patch
+
+**Files:**
+- Create outside upstream checkout: `luma-homelab/patches/agents-dev-cli/0001-add-hermes-integration.patch`
+
+**Steps:**
+1. Run `npm run build`.
+2. Run `npm run lint`.
+3. Run `npm test` and confirm all tests pass.
+4. Commit the upstream-compatible change on `feat/hermes-integration`.
+5. Export it with `git format-patch -1 --stdout` into the Home Lab Utilities worktree.
+6. Verify the patch applies cleanly to upstream `main` with `git apply --check`.
+
+### Task 7: Apply locally and synchronize Utilities
+
+**Files:**
+- Modify: each independently mapped workspace's `.agents/agents.json`
+- Modify: each independently mapped workspace's `.agents/local.json` only when a host-local endpoint override is required
+- Generated by sync: harness configuration files and Hermes profile configs
+
+**Steps:**
+1. Install/link the verified patched CLI locally without publishing it.
+2. Add `hermes` to enabled integrations and set that workspace's one `hermesProfile` value.
+3. Add `utilities-gateway` to each workspace with the appropriate harness targets and the portable tailnet endpoint in shared config. On Luma, resolve the service name to `127.0.0.1` with a host-only resolver entry; do not add a machine-specific local override.
+4. Run `agents sync`, followed by `agents sync --check`, `agents status --verbose`, `agents mcp test`, and `agents mcp test --runtime` in each workspace.
+5. Verify each workspace's one mapped Hermes profile contains Utilities and each supported generated harness contains the server.
+6. Restart the managed Hermes service only if runtime reload requires it, then confirm all profile logs register Utilities.

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,8 @@
         "@iarna/toml": "^2.2.5",
         "commander": "^14.0.3",
         "jsonc-parser": "^3.3.1",
-        "picocolors": "^1.1.1"
+        "picocolors": "^1.1.1",
+        "yaml": "^2.9.0"
       },
       "bin": {
         "agents": "bin/agents"
@@ -3044,6 +3045,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@agents-dev/cli",
   "version": "0.8.9",
-  "description": "One config to rule them all — sync MCP servers, skills, and AGENTS.md across Codex, Claude Code/Desktop, Gemini CLI, Cursor, Copilot VS Code/CLI, Antigravity, Windsurf, OpenCode, and Junie.",
+  "description": "One config to rule them all — sync MCP servers, skills, and AGENTS.md across Codex, Claude Code/Desktop, Gemini CLI, Cursor, Copilot VS Code/CLI, Antigravity, Windsurf, OpenCode, Junie, and Hermes Agent.",
   "main": "dist/cli.js",
   "scripts": {
     "build": "node -e \"const fs=require('node:fs'); fs.rmSync('dist',{recursive:true,force:true})\" && tsc -p tsconfig.json",
@@ -43,6 +43,7 @@
     "windsurf",
     "opencode",
     "junie",
+    "hermes-agent",
     "ai-coding",
     "llm-tools",
     "config-sync",
@@ -69,7 +70,8 @@
     "@iarna/toml": "^2.2.5",
     "commander": "^14.0.3",
     "jsonc-parser": "^3.3.1",
-    "picocolors": "^1.1.1"
+    "picocolors": "^1.1.1",
+    "yaml": "^2.9.0"
   },
   "devDependencies": {
     "@types/node": "^25.2.0",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -82,7 +82,7 @@ async function main(): Promise<void> {
     .command('connect')
     .description('Enable LLM integrations and sync')
     .option('--path <dir>', 'Target project directory', process.cwd())
-    .option('--llm <list>', 'Comma-separated list: codex,claude,claude_desktop,gemini,copilot_vscode,copilot_cli,cursor,antigravity,windsurf,opencode,junie')
+    .option('--llm <list>', 'Comma-separated list: codex,claude,claude_desktop,gemini,copilot_vscode,copilot_cli,cursor,antigravity,windsurf,opencode,junie,hermes')
     .option('--interactive', 'Open interactive selector')
     .option('--verbose', 'Print detailed sync output', false)
     .action(async (opts: { path: string; llm?: string; interactive?: boolean; verbose: boolean }) => {
@@ -98,7 +98,7 @@ async function main(): Promise<void> {
     .command('disconnect')
     .description('Disable LLM integrations and sync')
     .option('--path <dir>', 'Target project directory', process.cwd())
-    .option('--llm <list>', 'Comma-separated list: codex,claude,claude_desktop,gemini,copilot_vscode,copilot_cli,cursor,antigravity,windsurf,opencode,junie')
+    .option('--llm <list>', 'Comma-separated list: codex,claude,claude_desktop,gemini,copilot_vscode,copilot_cli,cursor,antigravity,windsurf,opencode,junie,hermes')
     .option('--interactive', 'Open interactive selector')
     .option('--verbose', 'Print detailed sync output', false)
     .action(async (opts: { path: string; llm?: string; interactive?: boolean; verbose: boolean }) => {

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -1,4 +1,5 @@
 import TOML from '@iarna/toml'
+import { parseDocument } from 'yaml'
 import { loadAgentsConfig } from '../core/config.js'
 import { getClaudeInstructionsHealth } from '../core/claudeInstructions.js'
 import {
@@ -10,6 +11,7 @@ import { loadResolvedRegistry } from '../core/mcp.js'
 import { getProjectPaths } from '../core/paths.js'
 import type { ProjectPaths } from '../core/paths.js'
 import { getWindsurfGlobalMcpPath } from '../core/windsurf.js'
+import { resolveHermesConfigPath } from '../core/hermes.js'
 import { commandExists, runCommand } from '../core/shell.js'
 import { performSync } from '../core/sync.js'
 import { ensureCodexProjectTrusted, getCodexTrustState } from '../core/trust.js'
@@ -133,6 +135,7 @@ export async function runDoctor(options: DoctorOptions): Promise<void> {
     enabledForMaterialization,
     claudeDesktopConfigPath,
     windsurfGlobalMcpPath,
+    resolveHermesConfigPath({ profile: config.integrations.options.hermesProfile }),
     issues,
   )
 
@@ -563,6 +566,7 @@ async function validateManagedConfigSyntax(
   enabledIntegrations: IntegrationName[],
   claudeDesktopConfigPath: string | undefined,
   windsurfGlobalMcpPath: string,
+  hermesConfigPath: string,
   issues: Issue[],
 ): Promise<void> {
   await validateTomlIfExists(paths.generatedCodex, '.agents/generated/codex.config.toml', issues)
@@ -576,6 +580,7 @@ async function validateManagedConfigSyntax(
   await validateJsonIfExists(paths.generatedClaude, '.agents/generated/claude.mcp.json', issues)
   await validateJsonIfExists(paths.generatedClaudeDesktop, '.agents/generated/claude-desktop.mcp.json', issues)
   await validateJsonIfExists(paths.generatedJunie, '.agents/generated/junie.mcp.json', issues)
+  await validateJsonIfExists(paths.generatedHermes, '.agents/generated/hermes.mcp.json', issues)
 
   if (enabledIntegrations.includes('codex')) {
     await validateTomlIfExists(paths.codexConfig, '.codex/config.toml', issues)
@@ -619,6 +624,9 @@ async function validateManagedConfigSyntax(
   if (enabledIntegrations.includes('junie')) {
     await validateJsonIfExists(paths.junieMcp, '.junie/mcp/mcp.json', issues)
   }
+  if (enabledIntegrations.includes('hermes')) {
+    await validateYamlIfExists(hermesConfigPath, `Hermes config (${hermesConfigPath})`, issues)
+  }
 }
 
 async function validateTomlIfExists(filePath: string, label: string, issues: Issue[]): Promise<void> {
@@ -642,6 +650,17 @@ async function validateJsonIfExists(filePath: string, label: string, issues: Iss
     issues.push({
       level: 'error',
       message: `Invalid JSON in ${label}: ${error instanceof Error ? error.message : String(error)}`
+    })
+  }
+}
+
+async function validateYamlIfExists(filePath: string, label: string, issues: Issue[]): Promise<void> {
+  if (!(await pathExists(filePath))) return
+  const document = parseDocument(await readTextOrEmpty(filePath))
+  if (document.errors.length > 0) {
+    issues.push({
+      level: 'error',
+      message: `Invalid YAML in ${label}: ${document.errors.map((error) => error.message).join('; ')}`
     })
   }
 }

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -20,7 +20,8 @@ export async function runInit(options: InitOptions): Promise<void> {
     integrations: [],
     integrationOptions: {
       cursorAutoApprove: true,
-      antigravityGlobalSync: true
+      antigravityGlobalSync: true,
+      hermesProfile: null
     },
     syncMode: 'source-only',
     hideGeneratedInVscode: true

--- a/src/commands/mcp-test.ts
+++ b/src/commands/mcp-test.ts
@@ -241,6 +241,7 @@ function runRuntimeChecks(entries: McpServerEntry[], projectRoot: string, timeou
         || integration === 'windsurf'
         || integration === 'opencode'
         || integration === 'junie'
+        || integration === 'hermes'
       ) {
         runtimeByIntegration[integration] = {
           status: 'unsupported',

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -105,8 +105,8 @@ export async function runStart(options: StartOptions): Promise<void> {
     interactive,
     autoApprove: options.yes || options.nonInteractive,
     integrationOptions: preserveExistingConfig
-      ? (existingConfig?.integrations.options ?? { cursorAutoApprove: true, antigravityGlobalSync: true })
-      : { cursorAutoApprove: true, antigravityGlobalSync: true },
+      ? (existingConfig?.integrations.options ?? { cursorAutoApprove: true, antigravityGlobalSync: true, hermesProfile: null })
+      : { cursorAutoApprove: true, antigravityGlobalSync: true, hermesProfile: null },
     allowOptionPrompts: !preserveExistingConfig
   })
 
@@ -239,7 +239,7 @@ async function resolveIntegrationAccess(args: {
   integrationOptions: AgentsConfig['integrations']['options']
   allowOptionPrompts: boolean
 }): Promise<{
-  integrationOptions: { cursorAutoApprove: boolean; antigravityGlobalSync: boolean }
+  integrationOptions: AgentsConfig['integrations']['options']
   summaries: Record<string, string>
   warnings: string[]
 }> {
@@ -250,7 +250,8 @@ async function resolveIntegrationAccess(args: {
 
   const integrationOptions = {
     cursorAutoApprove: baseOptions.cursorAutoApprove,
-    antigravityGlobalSync: baseOptions.antigravityGlobalSync
+    antigravityGlobalSync: baseOptions.antigravityGlobalSync,
+    hermesProfile: baseOptions.hermesProfile
   }
 
   if (selectedIntegrations.includes('codex')) {
@@ -343,6 +344,12 @@ async function resolveIntegrationAccess(args: {
     summaries.junie = 'project .junie/mcp/mcp.json + skills bridge'
   }
 
+  if (selectedIntegrations.includes('hermes')) {
+    summaries.hermes = integrationOptions.hermesProfile
+      ? `Hermes profile ${integrationOptions.hermesProfile}`
+      : 'active Hermes home'
+  }
+
   return {
     integrationOptions,
     summaries,
@@ -359,7 +366,8 @@ function formatSummaryKey(key: string): string {
     antigravity: 'Antigravity sync',
     windsurf: 'Windsurf sync',
     opencode: 'OpenCode sync',
-    junie: 'Junie sync'
+    junie: 'Junie sync',
+    hermes: 'Hermes sync'
   }
   return labels[key] ?? key
 }

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -2,6 +2,7 @@ import os from 'node:os'
 import path from 'node:path'
 import { readFile } from 'node:fs/promises'
 import { parse, type ParseError } from 'jsonc-parser'
+import { parse as parseYaml } from 'yaml'
 import { loadAgentsConfig } from '../core/config.js'
 import { listDirNames, pathExists, readJson } from '../core/fs.js'
 import { loadResolvedRegistry } from '../core/mcp.js'
@@ -14,6 +15,7 @@ import {
   toManagedClaudeDesktopName
 } from '../core/claudeDesktop.js'
 import { getWindsurfGlobalMcpPath } from '../core/windsurf.js'
+import { resolveHermesConfigPath } from '../core/hermes.js'
 import { commandExists, runCommand } from '../core/shell.js'
 import { getCodexTrustState } from '../core/trust.js'
 import { listMcpEntries, loadMcpState } from '../core/mcpCrud.js'
@@ -74,6 +76,8 @@ export async function runStatus(options: StatusOptions): Promise<void> {
   const claudeDesktopConfigLabel = claudeDesktopConfigPath ? toHomeRelativePath(claudeDesktopConfigPath) : undefined
   const windsurfGlobalPath = getWindsurfGlobalMcpPath()
   const windsurfGlobalLabel = toHomeRelativePath(windsurfGlobalPath)
+  const hermesConfigPath = resolveHermesConfigPath({ profile: config.integrations.options.hermesProfile })
+  const hermesConfigLabel = toHomeRelativePath(hermesConfigPath)
   const expectedCodexServers = resolved.serversByTarget.codex.map((server) => server.name)
   const expectedClaudeDesktopServers = resolved.serversByTarget.claude_desktop.map((server) => toManagedClaudeDesktopName(options.projectRoot, server.name))
   const expectedCopilotCliServers = resolved.serversByTarget.copilot_cli.map((server) => server.name)
@@ -82,6 +86,7 @@ export async function runStatus(options: StatusOptions): Promise<void> {
   const expectedWindsurfServers = resolved.serversByTarget.windsurf.map((server) => server.name)
   const expectedOpencodeServers = resolved.serversByTarget.opencode.map((server) => server.name)
   const expectedJunieServers = resolved.serversByTarget.junie.map((server) => server.name)
+  const expectedHermesServers = resolved.serversByTarget.hermes.map((server) => server.name)
 
   const files: Record<string, boolean> = {
     '.agents/agents.json': await pathExists(paths.agentsConfig),
@@ -120,6 +125,9 @@ export async function runStatus(options: StatusOptions): Promise<void> {
   if (enabled.has('junie')) {
     files['.junie/mcp/mcp.json'] = await pathExists(paths.junieMcp)
     files['.junie/skills'] = await pathExists(paths.junieSkillsBridge)
+  }
+  if (enabled.has('hermes')) {
+    files[hermesConfigLabel] = await pathExists(hermesConfigPath)
   }
   if (enabled.has('claude')) {
     files['CLAUDE.md'] = await pathExists(paths.rootClaudeMd)
@@ -168,6 +176,9 @@ export async function runStatus(options: StatusOptions): Promise<void> {
     if (enabled.has('junie')) {
       probes.junie = await probeMcpServersFile(paths.junieMcp, '.junie/mcp/mcp.json', 'mcpServers', expectedJunieServers)
     }
+    if (enabled.has('hermes')) {
+      probes.hermes = await probeHermes(hermesConfigPath, hermesConfigLabel, expectedHermesServers)
+    }
     probes.skills = await probeSkills(paths.agentsSkillsDir)
     probes.vscode_hidden = await probeVscodeHidden(paths.vscodeSettings)
   }
@@ -210,7 +221,7 @@ export async function runStatus(options: StatusOptions): Promise<void> {
     ui.keyValue('MCP', `${output.mcp.configured} configured, ${output.mcp.localOverrides} local override(s)`)
     ui.keyValue('Selected MCP', ui.formatList(output.selectedMcpServers))
 
-    const compactProbeOrder = ['codex', 'claude', 'claude_desktop', 'gemini', 'copilot_vscode', 'copilot_cli', 'cursor', 'antigravity', 'windsurf', 'opencode', 'junie']
+    const compactProbeOrder = ['codex', 'claude', 'claude_desktop', 'gemini', 'copilot_vscode', 'copilot_cli', 'cursor', 'antigravity', 'windsurf', 'opencode', 'junie', 'hermes']
     const compactProbes = compactProbeOrder
       .filter((name) => Boolean(output.probes[name]))
       .map((name) => `${name}: ${output.probes[name]}`)
@@ -442,6 +453,21 @@ async function probeOpencode(configPath: string, expectedServerNames: string[]):
     return `${names.length} server(s) configured`
   } catch {
     return 'invalid opencode.json'
+  }
+}
+
+async function probeHermes(configPath: string, label: string, expectedServerNames: string[]): Promise<string> {
+  if (!(await pathExists(configPath))) return `missing ${label}`
+  try {
+    const parsed = parseYaml(await readFile(configPath, 'utf8')) as { mcp_servers?: Record<string, unknown> } | null
+    const names = Object.keys(parsed?.mcp_servers ?? {})
+    const missing = expectedServerNames.filter((name) => !names.includes(name))
+    if (missing.length > 0) {
+      return `${expectedServerNames.length - missing.length} managed server(s) configured; missing expected: ${missing.join(', ')}`
+    }
+    return `${expectedServerNames.length} managed server(s) configured`
+  } catch {
+    return `invalid ${label}`
   }
 }
 

--- a/src/core/codexConfig.ts
+++ b/src/core/codexConfig.ts
@@ -1,0 +1,63 @@
+import TOML from '@iarna/toml'
+
+export const CODEX_MANAGED_MCP_BEGIN = '# BEGIN agents-sync managed MCP'
+export const CODEX_MANAGED_MCP_END = '# END agents-sync managed MCP'
+
+/**
+ * Merge generated MCP tables into a Codex project config without rewriting
+ * project-owned settings. Agent Sync owns only the text between its markers.
+ */
+export function mergeCodexConfig(existingContent: string, generatedContent: string): string {
+  validateToml(existingContent, 'existing Codex TOML')
+  validateToml(generatedContent, 'generated Codex TOML')
+
+  const beginIndex = existingContent.indexOf(CODEX_MANAGED_MCP_BEGIN)
+  const endIndex = existingContent.indexOf(CODEX_MANAGED_MCP_END)
+  const hasBegin = beginIndex >= 0
+  const hasEnd = endIndex >= 0
+
+  if (
+    hasBegin !== hasEnd
+    || (hasBegin && beginIndex !== existingContent.lastIndexOf(CODEX_MANAGED_MCP_BEGIN))
+    || (hasEnd && endIndex !== existingContent.lastIndexOf(CODEX_MANAGED_MCP_END))
+    || (hasBegin && endIndex < beginIndex)
+  ) {
+    throw new Error('Invalid existing Codex TOML: malformed agents-sync managed MCP block')
+  }
+
+  const managedBlock = [
+    CODEX_MANAGED_MCP_BEGIN,
+    generatedContent.trimEnd(),
+    CODEX_MANAGED_MCP_END
+  ].join('\n')
+
+  let merged: string
+  if (hasBegin && hasEnd) {
+    merged = [
+      existingContent.slice(0, beginIndex),
+      managedBlock,
+      existingContent.slice(endIndex + CODEX_MANAGED_MCP_END.length)
+    ].join('')
+  } else if (existingContent.length === 0) {
+    merged = `${managedBlock}\n`
+  } else {
+    const separator = existingContent.endsWith('\n')
+      ? (existingContent.endsWith('\n\n') ? '' : '\n')
+      : '\n\n'
+    merged = `${existingContent}${separator}${managedBlock}\n`
+  }
+
+  validateToml(merged, 'merged Codex TOML')
+  return merged
+}
+
+function validateToml(content: string, label: string): void {
+  if (content.trim().length === 0) return
+
+  try {
+    TOML.parse(content)
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    throw new Error(`Invalid ${label}: ${message}`)
+  }
+}

--- a/src/core/codexConfig.ts
+++ b/src/core/codexConfig.ts
@@ -3,6 +3,13 @@ import TOML from '@iarna/toml'
 export const CODEX_MANAGED_MCP_BEGIN = '# BEGIN agents-sync managed MCP'
 export const CODEX_MANAGED_MCP_END = '# END agents-sync managed MCP'
 
+type TomlLexState = 'normal' | 'basic' | 'literal' | 'multilineBasic' | 'multilineLiteral'
+
+interface StandaloneCommentLine {
+  start: number
+  contentEnd: number
+}
+
 /**
  * Merge generated MCP tables into a Codex project config without rewriting
  * project-owned settings. Agent Sync owns only the text between its markers.
@@ -11,44 +18,152 @@ export function mergeCodexConfig(existingContent: string, generatedContent: stri
   validateToml(existingContent, 'existing Codex TOML')
   validateToml(generatedContent, 'generated Codex TOML')
 
-  const beginIndex = existingContent.indexOf(CODEX_MANAGED_MCP_BEGIN)
-  const endIndex = existingContent.indexOf(CODEX_MANAGED_MCP_END)
-  const hasBegin = beginIndex >= 0
-  const hasEnd = endIndex >= 0
+  const beginLines = findStandaloneCommentLines(existingContent, CODEX_MANAGED_MCP_BEGIN)
+  const endLines = findStandaloneCommentLines(existingContent, CODEX_MANAGED_MCP_END)
+  const beginLine = beginLines[0]
+  const endLine = endLines[0]
+  const hasBegin = beginLine !== undefined
+  const hasEnd = endLine !== undefined
 
   if (
     hasBegin !== hasEnd
-    || (hasBegin && beginIndex !== existingContent.lastIndexOf(CODEX_MANAGED_MCP_BEGIN))
-    || (hasEnd && endIndex !== existingContent.lastIndexOf(CODEX_MANAGED_MCP_END))
-    || (hasBegin && endIndex < beginIndex)
+    || beginLines.length > 1
+    || endLines.length > 1
+    || (beginLine !== undefined && endLine !== undefined && endLine.start < beginLine.start)
   ) {
     throw new Error('Invalid existing Codex TOML: malformed agents-sync managed MCP block')
   }
 
+  const lineEnding = existingContent.includes('\r\n') ? '\r\n' : '\n'
+  const normalizedGenerated = generatedContent
+    .trimEnd()
+    .replace(/\r\n|\n/g, lineEnding)
   const managedBlock = [
     CODEX_MANAGED_MCP_BEGIN,
-    generatedContent.trimEnd(),
+    normalizedGenerated,
     CODEX_MANAGED_MCP_END
-  ].join('\n')
+  ].join(lineEnding)
 
   let merged: string
-  if (hasBegin && hasEnd) {
+  if (beginLine !== undefined && endLine !== undefined) {
     merged = [
-      existingContent.slice(0, beginIndex),
+      existingContent.slice(0, beginLine.start),
       managedBlock,
-      existingContent.slice(endIndex + CODEX_MANAGED_MCP_END.length)
+      existingContent.slice(endLine.contentEnd)
     ].join('')
   } else if (existingContent.length === 0) {
-    merged = `${managedBlock}\n`
+    merged = `${managedBlock}${lineEnding}`
   } else {
-    const separator = existingContent.endsWith('\n')
-      ? (existingContent.endsWith('\n\n') ? '' : '\n')
-      : '\n\n'
-    merged = `${existingContent}${separator}${managedBlock}\n`
+    const separator = existingContent.endsWith('\n') ? '' : lineEnding
+    merged = `${existingContent}${separator}${managedBlock}${lineEnding}`
   }
 
   validateToml(merged, 'merged Codex TOML')
   return merged
+}
+
+function findStandaloneCommentLines(content: string, marker: string): StandaloneCommentLine[] {
+  const matches: StandaloneCommentLine[] = []
+  let state: TomlLexState = 'normal'
+  let lineStart = 0
+
+  while (lineStart <= content.length) {
+    const newlineIndex = content.indexOf('\n', lineStart)
+    const lineBreakStart = newlineIndex >= 0 ? newlineIndex : content.length
+    const contentEnd = lineBreakStart > lineStart && content[lineBreakStart - 1] === '\r'
+      ? lineBreakStart - 1
+      : lineBreakStart
+
+    if (state === 'normal' && content.slice(lineStart, contentEnd) === marker) {
+      matches.push({ start: lineStart, contentEnd })
+    }
+
+    state = scanTomlLine(content, lineStart, contentEnd, state)
+    if (newlineIndex < 0) break
+    lineStart = newlineIndex + 1
+  }
+
+  return matches
+}
+
+function scanTomlLine(
+  content: string,
+  start: number,
+  end: number,
+  initialState: TomlLexState,
+): TomlLexState {
+  let state = initialState
+  let index = start
+
+  while (index < end) {
+    if (state === 'normal') {
+      if (content[index] === '#') break
+      if (content.startsWith('"""', index)) {
+        state = 'multilineBasic'
+        index += 3
+        continue
+      }
+      if (content.startsWith("'''", index)) {
+        state = 'multilineLiteral'
+        index += 3
+        continue
+      }
+      if (content[index] === '"') {
+        state = 'basic'
+      } else if (content[index] === "'") {
+        state = 'literal'
+      }
+      index += 1
+      continue
+    }
+
+    if (state === 'basic') {
+      if (content[index] === '\\') {
+        index += 2
+        continue
+      }
+      if (content[index] === '"') state = 'normal'
+      index += 1
+      continue
+    }
+
+    if (state === 'literal') {
+      if (content[index] === "'") state = 'normal'
+      index += 1
+      continue
+    }
+
+    if (state === 'multilineBasic') {
+      if (content[index] === '\\') {
+        index += 2
+        continue
+      }
+      if (content.startsWith('"""', index)) {
+        index = consumeQuoteRun(content, index, end, '"')
+        state = 'normal'
+        continue
+      }
+      index += 1
+      continue
+    }
+
+    if (content.startsWith("'''", index)) {
+      index = consumeQuoteRun(content, index, end, "'")
+      state = 'normal'
+      continue
+    }
+    index += 1
+  }
+
+  return state
+}
+
+function consumeQuoteRun(content: string, start: number, end: number, quote: '"' | "'"): number {
+  let index = start
+  while (index < end && content[index] === quote) {
+    index += 1
+  }
+  return index
 }
 
 function validateToml(content: string, label: string): void {

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -30,7 +30,8 @@ const DEFAULT_TARGETS: IntegrationName[] = [
   'antigravity',
   'windsurf',
   'opencode',
-  'junie'
+  'junie',
+  'hermes'
 ]
 
 const DEFAULT_MCP_SERVERS: Record<string, McpServerDefinition> = {
@@ -74,6 +75,7 @@ export function createDefaultAgentsConfig(args?: {
   integrationOptions?: {
     cursorAutoApprove: boolean
     antigravityGlobalSync: boolean
+    hermesProfile: string | null
   }
   syncMode?: SyncMode
   hideGenerated?: boolean
@@ -89,7 +91,8 @@ export function createDefaultAgentsConfig(args?: {
       enabled: [...(args?.enabledIntegrations ?? [])],
       options: {
         cursorAutoApprove: args?.integrationOptions?.cursorAutoApprove !== false,
-        antigravityGlobalSync: args?.integrationOptions?.antigravityGlobalSync !== false
+        antigravityGlobalSync: args?.integrationOptions?.antigravityGlobalSync !== false,
+        hermesProfile: normalizeHermesProfile(args?.integrationOptions?.hermesProfile)
       }
     },
     syncMode: args?.syncMode ?? 'source-only',
@@ -132,7 +135,8 @@ export async function loadAgentsConfig(projectRoot: string): Promise<AgentsConfi
       : [],
     options: {
       cursorAutoApprove: config.integrations?.options?.cursorAutoApprove !== false,
-      antigravityGlobalSync: config.integrations?.options?.antigravityGlobalSync !== false
+      antigravityGlobalSync: config.integrations?.options?.antigravityGlobalSync !== false,
+      hermesProfile: normalizeHermesProfile(config.integrations?.options?.hermesProfile)
     }
   }
 
@@ -164,6 +168,10 @@ export async function loadAgentsConfig(projectRoot: string): Promise<AgentsConfi
   }
 
   return config
+}
+
+function normalizeHermesProfile(value: unknown): string | null {
+  return typeof value === 'string' && value.trim() ? value.trim() : null
 }
 
 export async function saveAgentsConfig(projectRoot: string, config: AgentsConfig): Promise<void> {

--- a/src/core/hermes.ts
+++ b/src/core/hermes.ts
@@ -1,0 +1,121 @@
+import os from 'node:os'
+import path from 'node:path'
+import { parseDocument } from 'yaml'
+
+export interface HermesManagedState {
+  configs: Record<string, string[]>
+}
+
+export interface ResolveHermesConfigPathOptions {
+  profile: string | null
+  env?: NodeJS.ProcessEnv
+  homeDir?: string
+}
+
+/** Resolve the single Hermes YAML file owned by the current workspace. */
+export function resolveHermesConfigPath(
+  options: ResolveHermesConfigPathOptions,
+): string {
+  const env = options.env ?? process.env
+  const homeDir = options.homeDir ?? os.homedir()
+  const explicit = env.AGENTS_HERMES_CONFIG_PATH?.trim()
+  if (explicit) {
+    return expandHome(explicit, homeDir)
+  }
+
+  const profile = options.profile?.trim()
+  if (profile) {
+    if (!/^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(profile) || profile === '.' || profile === '..') {
+      throw new Error(`Invalid Hermes profile: ${profile}`)
+    }
+    return path.join(homeDir, '.hermes', 'profiles', profile, 'config.yaml')
+  }
+
+  const hermesHome = expandHome(
+    env.HERMES_HOME?.trim() || path.join(homeDir, '.hermes'),
+    homeDir,
+  )
+  return path.join(hermesHome, 'config.yaml')
+}
+
+/**
+ * Merge Agent Sync-owned MCP servers into a Hermes config document while
+ * preserving unrelated YAML nodes and comments.
+ */
+export function mergeHermesConfig(
+  source: string,
+  previousManagedNames: string[],
+  nextServers: Record<string, Record<string, unknown>>,
+): string {
+  const document = parseDocument(source.trim() ? source : '{}\n')
+  if (document.errors.length > 0) {
+    throw new Error(`Failed to parse Hermes config: ${document.errors.map((error) => error.message).join('; ')}`)
+  }
+
+  const rootValue = document.toJS()
+  if (!isRecord(rootValue)) {
+    throw new Error('Failed to parse Hermes config: root must be a mapping')
+  }
+
+  if (!isRecord(rootValue.mcp_servers)) {
+    document.set('mcp_servers', document.createNode({}))
+  }
+
+  const previous = [...new Set(previousManagedNames.filter((name) => typeof name === 'string'))]
+  for (const name of previous) {
+    document.deleteIn(['mcp_servers', name])
+  }
+
+  const nextNames = Object.keys(nextServers).sort((a, b) => a.localeCompare(b))
+  for (const name of nextNames) {
+    document.setIn(['mcp_servers', name], nextServers[name])
+  }
+
+  const platformToolsets = rootValue.platform_toolsets
+  if (isRecord(platformToolsets)) {
+    for (const [platform, rawEntries] of Object.entries(platformToolsets)) {
+      if (!Array.isArray(rawEntries)) continue
+      const filtered = rawEntries
+        .map((entry) => String(entry))
+        .filter((entry) => !previous.includes(entry))
+      if (!filtered.includes('no_mcp')) {
+        for (const name of nextNames) {
+          if (!filtered.includes(name)) filtered.push(name)
+        }
+      }
+      document.setIn(['platform_toolsets', platform], filtered)
+    }
+  }
+
+  const rendered = document.toString()
+  return rendered.endsWith('\n') ? rendered : `${rendered}\n`
+}
+
+/** Normalize persisted Hermes ownership state without trusting its shape. */
+export function normalizeHermesManagedState(value: unknown): HermesManagedState {
+  if (!isRecord(value) || !isRecord(value.configs)) {
+    return { configs: {} }
+  }
+
+  const configs: Record<string, string[]> = {}
+  for (const [configPath, names] of Object.entries(value.configs)) {
+    if (!Array.isArray(names)) continue
+    const normalized = [...new Set(names.filter((name): name is string => typeof name === 'string'))]
+      .sort((a, b) => a.localeCompare(b))
+    configs[configPath] = normalized
+  }
+  return { configs }
+}
+
+function expandHome(value: string, homeDir: string): string {
+  if (value === '~') return homeDir
+  if (value.startsWith(`~${path.sep}`)) {
+    return path.join(homeDir, value.slice(2))
+  }
+  return path.resolve(value)
+}
+
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}

--- a/src/core/mcp.ts
+++ b/src/core/mcp.ts
@@ -61,7 +61,8 @@ export function resolveFromConfigAndLocal(input: {
     antigravity: [],
     windsurf: [],
     opencode: [],
-    junie: []
+    junie: [],
+    hermes: []
   }
 
   const selectedServerNames: string[] = []

--- a/src/core/paths.ts
+++ b/src/core/paths.ts
@@ -15,6 +15,8 @@ export interface ProjectPaths {
   generatedCopilot: string
   generatedCopilotCli: string
   generatedCursor: string
+  generatedHermes: string
+  generatedHermesState: string
   generatedAntigravity: string
   generatedAntigravityState: string
   generatedWindsurf: string
@@ -83,6 +85,8 @@ export function getProjectPaths(projectRoot: string): ProjectPaths {
     generatedCopilot: path.join(generatedDir, 'copilot.vscode.mcp.json'),
     generatedCopilotCli: path.join(generatedDir, 'copilot.cli.mcp.json'),
     generatedCursor: path.join(generatedDir, 'cursor.mcp.json'),
+    generatedHermes: path.join(generatedDir, 'hermes.mcp.json'),
+    generatedHermesState: path.join(generatedDir, 'hermes.state.json'),
     generatedAntigravity: path.join(generatedDir, 'antigravity.mcp_config.json'),
     generatedAntigravityState: path.join(generatedDir, 'antigravity.state.json'),
     generatedWindsurf: path.join(generatedDir, 'windsurf.mcp.json'),

--- a/src/integrations/hermes.ts
+++ b/src/integrations/hermes.ts
@@ -1,0 +1,42 @@
+import type { ResolvedMcpServer } from '../types.js'
+
+export interface HermesPayload {
+  mcpServers: Record<string, Record<string, unknown>>
+  warnings: string[]
+}
+
+/**
+ * Convert resolved Agent Sync MCP definitions to Hermes Agent's native
+ * `mcp_servers` mapping.
+ */
+export function buildHermesPayload(servers: ResolvedMcpServer[]): HermesPayload {
+  const mcpServers: Record<string, Record<string, unknown>> = {}
+  const warnings: string[] = []
+
+  for (const server of servers) {
+    const rendered: Record<string, unknown> = { enabled: true }
+
+    if (server.transport === 'stdio') {
+      rendered.command = server.command
+      rendered.args = server.args ?? []
+      if (server.env && Object.keys(server.env).length > 0) {
+        rendered.env = server.env
+      }
+      if (server.cwd) {
+        warnings.push(`Hermes MCP server "${server.name}" does not support cwd; omitted ${server.cwd}.`)
+      }
+    } else {
+      rendered.url = server.url
+      if (server.transport === 'sse') {
+        rendered.transport = 'sse'
+      }
+      if (server.headers && Object.keys(server.headers).length > 0) {
+        rendered.headers = server.headers
+      }
+    }
+
+    mcpServers[server.name] = rendered
+  }
+
+  return { mcpServers, warnings }
+}

--- a/src/integrations/registry.ts
+++ b/src/integrations/registry.ts
@@ -17,7 +17,8 @@ export const INTEGRATIONS: IntegrationDefinition[] = [
   { id: 'antigravity', label: 'Antigravity', requiredBinary: 'agy' },
   { id: 'windsurf', label: 'Windsurf' },
   { id: 'opencode', label: 'OpenCode' },
-  { id: 'junie', label: 'Junie', requiredBinary: 'junie' }
+  { id: 'junie', label: 'Junie', requiredBinary: 'junie' },
+  { id: 'hermes', label: 'Hermes Agent', requiredBinary: 'hermes' }
 ]
 
 export const INTEGRATION_IDS: IntegrationName[] = INTEGRATIONS.map((item) => item.id)

--- a/src/integrations/syncHooks.ts
+++ b/src/integrations/syncHooks.ts
@@ -1,11 +1,12 @@
 import path from 'node:path'
-import { ensureDir, pathExists, readJson, writeJsonAtomic } from '../core/fs.js'
+import { ensureDir, pathExists, readJson, readTextOrEmpty, writeJsonAtomic } from '../core/fs.js'
 import { writeManagedFile } from '../core/managedFiles.js'
 import { getLegacyAntigravityGlobalMcpPath, normalizeAntigravityMcpPayload, readAntigravityMcp } from '../core/antigravity.js'
 import { getWindsurfGlobalMcpPath, normalizeWindsurfMcpPayload, readWindsurfMcp } from '../core/windsurf.js'
 import { normalizeOpencodeConfig } from '../core/opencode.js'
 import { renderVscodeMcp } from '../core/renderers.js'
 import { acquireSyncLock } from '../core/syncLock.js'
+import { mergeHermesConfig, normalizeHermesManagedState, resolveHermesConfigPath } from '../core/hermes.js'
 import { buildAntigravityPayload } from './antigravity.js'
 import { buildCodexConfig } from './codex.js'
 import { buildCopilotCliPayload } from './copilotCli.js'
@@ -15,6 +16,7 @@ import { buildGeminiPayload } from './gemini.js'
 import { buildOpencodePayload } from './opencode.js'
 import { buildWindsurfPayload } from './windsurf.js'
 import { buildJuniePayload } from './junie.js'
+import { buildHermesPayload } from './hermes.js'
 import type { ProjectPaths } from '../core/paths.js'
 import type { AgentsConfig, IntegrationName, ResolvedMcpServer } from '../types.js'
 
@@ -326,6 +328,31 @@ export const INTEGRATION_SYNC_HOOKS: IntegrationSyncHook[] = [
     }
   },
   {
+    id: 'hermes',
+    generatedPath: (paths) => paths.generatedHermes,
+    buildGenerated: (servers) => {
+      const hermes = buildHermesPayload(servers)
+      return {
+        content: `${JSON.stringify({ mcpServers: hermes.mcpServers }, null, 2)}\n`,
+        warnings: hermes.warnings
+      }
+    },
+    materializeWhenDisabled: true,
+    materialize: async (context) => {
+      await syncManagedHermesConfig({
+        enabled: context.enabled,
+        configPath: resolveHermesConfigPath({
+          profile: context.config.integrations.options.hermesProfile
+        }),
+        statePath: context.paths.generatedHermesState,
+        rawGenerated: context.generatedByIntegration.hermes ?? '',
+        projectRoot: context.projectRoot,
+        check: context.check,
+        changed: context.changed
+      })
+    }
+  },
+  {
     id: 'claude',
     generatedPath: (paths) => paths.generatedClaude,
     buildGenerated: (servers) => {
@@ -337,6 +364,86 @@ export const INTEGRATION_SYNC_HOOKS: IntegrationSyncHook[] = [
     }
   }
 ]
+
+async function syncManagedHermesConfig(args: {
+  enabled: boolean
+  configPath: string
+  statePath: string
+  rawGenerated: string
+  projectRoot: string
+  check: boolean
+  changed: string[]
+}): Promise<void> {
+  const state = await readHermesManagedState(args.statePath)
+  const generated = args.enabled && args.rawGenerated.trim()
+    ? parseJsonObject(args.rawGenerated, 'generated Hermes config')
+    : {}
+  const nextServers = recordFrom(generated.mcpServers) as Record<string, Record<string, unknown>>
+
+  for (const [previousPath, previousNames] of Object.entries(state.configs)) {
+    if (args.enabled && previousPath === args.configPath) continue
+    await applyHermesMerge({
+      configPath: previousPath,
+      previousNames,
+      nextServers: {},
+      projectRoot: args.projectRoot,
+      check: args.check,
+      changed: args.changed
+    })
+  }
+
+  if (args.enabled) {
+    await applyHermesMerge({
+      configPath: args.configPath,
+      previousNames: state.configs[args.configPath] ?? [],
+      nextServers,
+      projectRoot: args.projectRoot,
+      check: args.check,
+      changed: args.changed
+    })
+  }
+
+  if (!args.check) {
+    await writeJsonAtomic(args.statePath, {
+      configs: args.enabled
+        ? { [args.configPath]: Object.keys(nextServers).sort((a, b) => a.localeCompare(b)) }
+        : {}
+    })
+  }
+}
+
+async function applyHermesMerge(args: {
+  configPath: string
+  previousNames: string[]
+  nextServers: Record<string, Record<string, unknown>>
+  projectRoot: string
+  check: boolean
+  changed: string[]
+}): Promise<void> {
+  const releaseLock = args.check ? null : await acquireSyncLock(`${args.configPath}.agents-sync.lock`)
+  try {
+    const source = await readTextOrEmpty(args.configPath)
+    const content = mergeHermesConfig(source, args.previousNames, args.nextServers)
+    await writeManagedFile({
+      absolutePath: args.configPath,
+      content,
+      projectRoot: args.projectRoot,
+      check: args.check,
+      changed: args.changed
+    })
+  } finally {
+    if (releaseLock) await releaseLock()
+  }
+}
+
+async function readHermesManagedState(statePath: string) {
+  if (!(await pathExists(statePath))) return normalizeHermesManagedState(null)
+  try {
+    return normalizeHermesManagedState(await readJson<unknown>(statePath))
+  } catch {
+    return normalizeHermesManagedState(null)
+  }
+}
 
 function parseJsonObject(raw: string, label: string): Record<string, unknown> {
   try {

--- a/src/integrations/syncHooks.ts
+++ b/src/integrations/syncHooks.ts
@@ -1,6 +1,7 @@
 import path from 'node:path'
 import { ensureDir, pathExists, readJson, readTextOrEmpty, writeJsonAtomic } from '../core/fs.js'
 import { writeManagedFile } from '../core/managedFiles.js'
+import { mergeCodexConfig } from '../core/codexConfig.js'
 import { getLegacyAntigravityGlobalMcpPath, normalizeAntigravityMcpPayload, readAntigravityMcp } from '../core/antigravity.js'
 import { getWindsurfGlobalMcpPath, normalizeWindsurfMcpPayload, readWindsurfMcp } from '../core/windsurf.js'
 import { normalizeOpencodeConfig } from '../core/opencode.js'
@@ -57,8 +58,10 @@ export const INTEGRATION_SYNC_HOOKS: IntegrationSyncHook[] = [
       }
     },
     materialize: async (context) => {
-      const content = context.generatedByIntegration.codex ?? ''
+      const generatedContent = context.generatedByIntegration.codex ?? ''
       const targetPath = context.paths.codexConfig
+      const existingContent = await readTextOrEmpty(targetPath)
+      const content = mergeCodexConfig(existingContent, generatedContent)
       await writeManagedFile({
         absolutePath: targetPath,
         content,

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,6 +12,7 @@ export type IntegrationName =
   | 'windsurf'
   | 'opencode'
   | 'junie'
+  | 'hermes'
 export type SyncMode = 'source-only' | 'commit-generated'
 
 export type McpTransportType = 'stdio' | 'http' | 'sse'
@@ -26,6 +27,7 @@ export interface AgentsConfig {
     options: {
       cursorAutoApprove: boolean
       antigravityGlobalSync: boolean
+      hermesProfile: string | null
     }
   }
   syncMode: SyncMode

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -13,6 +13,34 @@ afterEach(async () => {
 })
 
 describe('config loading', () => {
+  it('defaults the Hermes profile target to the active home', () => {
+    const config = createDefaultAgentsConfig()
+
+    expect(config.integrations.options.hermesProfile).toBeNull()
+  })
+
+  it('preserves an explicit per-workspace Hermes profile target', async () => {
+    const projectRoot = await mkdtemp(path.join(os.tmpdir(), 'agents-config-'))
+    tempDirs.push(projectRoot)
+    const config = createDefaultAgentsConfig({
+      integrationOptions: {
+        cursorAutoApprove: true,
+        antigravityGlobalSync: true,
+        hermesProfile: 'home-lab'
+      }
+    })
+
+    await mkdir(path.join(projectRoot, '.agents'), { recursive: true })
+    await writeFile(
+      path.join(projectRoot, '.agents', 'agents.json'),
+      `${JSON.stringify(config, null, 2)}\n`,
+      'utf8'
+    )
+
+    const loaded = await loadAgentsConfig(projectRoot)
+    expect(loaded.integrations.options.hermesProfile).toBe('home-lab')
+  })
+
   it('falls back to source-only when syncMode is invalid', async () => {
     const projectRoot = await mkdtemp(path.join(os.tmpdir(), 'agents-config-'))
     tempDirs.push(projectRoot)

--- a/tests/doctor.integration.test.ts
+++ b/tests/doctor.integration.test.ts
@@ -9,10 +9,12 @@ import { performSync } from '../src/core/sync.js'
 
 const tempDirs: string[] = []
 let previousClaudeDesktopConfigPath: string | undefined
+let previousHermesConfigPath: string | undefined
 
 beforeEach(() => {
   process.exitCode = undefined
   previousClaudeDesktopConfigPath = process.env.AGENTS_CLAUDE_DESKTOP_CONFIG_PATH
+  previousHermesConfigPath = process.env.AGENTS_HERMES_CONFIG_PATH
 })
 
 afterEach(async () => {
@@ -21,6 +23,11 @@ afterEach(async () => {
     delete process.env.AGENTS_CLAUDE_DESKTOP_CONFIG_PATH
   } else {
     process.env.AGENTS_CLAUDE_DESKTOP_CONFIG_PATH = previousClaudeDesktopConfigPath
+  }
+  if (previousHermesConfigPath === undefined) {
+    delete process.env.AGENTS_HERMES_CONFIG_PATH
+  } else {
+    process.env.AGENTS_HERMES_CONFIG_PATH = previousHermesConfigPath
   }
   for (const dir of tempDirs.splice(0, tempDirs.length)) {
     await rm(dir, { recursive: true, force: true })
@@ -191,6 +198,27 @@ describe('doctor command', () => {
     })
 
     expect(output).toContain('Invalid JSON in Claude Desktop config')
+    expect(process.exitCode).toBe(1)
+  }, 15000)
+
+  it('reports invalid YAML in the workspace Hermes config', async () => {
+    const projectRoot = await mkdtemp(path.join(os.tmpdir(), 'agents-doctor-'))
+    const hermesRoot = await mkdtemp(path.join(os.tmpdir(), 'agents-doctor-hermes-'))
+    tempDirs.push(projectRoot, hermesRoot)
+    const hermesConfigPath = path.join(hermesRoot, 'config.yaml')
+    process.env.AGENTS_HERMES_CONFIG_PATH = hermesConfigPath
+
+    await runInit({ projectRoot, force: true })
+    const config = await loadAgentsConfig(projectRoot)
+    config.integrations.enabled = ['hermes']
+    await saveAgentsConfig(projectRoot, config)
+    await writeFile(hermesConfigPath, 'mcp_servers: [invalid\n', 'utf8')
+
+    const output = await captureStdout(async () => {
+      await runDoctor({ projectRoot, fix: false })
+    })
+
+    expect(output).toContain('Invalid YAML in Hermes config')
     expect(process.exitCode).toBe(1)
   }, 15000)
 })

--- a/tests/hermes-sync.integration.test.ts
+++ b/tests/hermes-sync.integration.test.ts
@@ -1,0 +1,99 @@
+import os from 'node:os'
+import path from 'node:path'
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { afterEach, describe, expect, it } from 'vitest'
+import { parse } from 'yaml'
+import { runInit } from '../src/commands/init.js'
+import { loadAgentsConfig, saveAgentsConfig } from '../src/core/config.js'
+import { getProjectPaths } from '../src/core/paths.js'
+import { performSync } from '../src/core/sync.js'
+
+const tempDirs: string[] = []
+const originalHermesConfigPath = process.env.AGENTS_HERMES_CONFIG_PATH
+
+interface HermesTestConfig {
+  mcp_servers: Record<string, { url?: string } | undefined>
+  platform_toolsets: Record<string, string[]>
+}
+
+afterEach(async () => {
+  if (originalHermesConfigPath === undefined) {
+    delete process.env.AGENTS_HERMES_CONFIG_PATH
+  } else {
+    process.env.AGENTS_HERMES_CONFIG_PATH = originalHermesConfigPath
+  }
+  for (const dir of tempDirs.splice(0, tempDirs.length)) {
+    await rm(dir, { recursive: true, force: true })
+  }
+})
+
+describe('Hermes workspace sync', () => {
+  it('merges, checks, retargets and cleans only workspace-owned servers', async () => {
+    const projectRoot = await mkdtemp(path.join(os.tmpdir(), 'agents-hermes-sync-'))
+    const hermesRoot = await mkdtemp(path.join(os.tmpdir(), 'agents-hermes-configs-'))
+    tempDirs.push(projectRoot, hermesRoot)
+    const firstConfig = path.join(hermesRoot, 'first', 'config.yaml')
+    const secondConfig = path.join(hermesRoot, 'second', 'config.yaml')
+    await mkdir(path.dirname(firstConfig), { recursive: true })
+    await mkdir(path.dirname(secondConfig), { recursive: true })
+    const manualYaml = `# preserve me
+mcp_servers:
+  manual:
+    url: https://manual.example/mcp
+platform_toolsets:
+  telegram: [manual]
+`
+    await writeFile(firstConfig, manualYaml, 'utf8')
+    await writeFile(secondConfig, manualYaml, 'utf8')
+
+    await runInit({ projectRoot, force: true })
+    const config = await loadAgentsConfig(projectRoot)
+    config.integrations.enabled = ['hermes']
+    config.integrations.options.hermesProfile = 'ignored-by-test-override'
+    config.mcp.servers = {
+      utilities: {
+        transport: 'http',
+        url: 'https://utilities.example/v1/mcp',
+        targets: ['hermes']
+      }
+    }
+    await saveAgentsConfig(projectRoot, config)
+
+    process.env.AGENTS_HERMES_CONFIG_PATH = firstConfig
+    await performSync({ projectRoot, check: false, verbose: false })
+    const firstApplied = parse(await readFile(firstConfig, 'utf8')) as HermesTestConfig
+    expect(firstApplied.mcp_servers.manual.url).toBe('https://manual.example/mcp')
+    expect(firstApplied.mcp_servers.utilities.url).toBe('https://utilities.example/v1/mcp')
+    expect(firstApplied.platform_toolsets.telegram).toEqual(['manual', 'utilities'])
+
+    const cleanCheck = await performSync({ projectRoot, check: true, verbose: false })
+    expect(cleanCheck.changed).not.toContain(firstConfig)
+
+    config.mcp.servers.utilities.url = 'https://utilities.example/v2/mcp'
+    await saveAgentsConfig(projectRoot, config)
+    const beforeCheck = await readFile(firstConfig, 'utf8')
+    const drift = await performSync({ projectRoot, check: true, verbose: false })
+    expect(drift.changed).toContain(firstConfig)
+    expect(await readFile(firstConfig, 'utf8')).toBe(beforeCheck)
+    await performSync({ projectRoot, check: false, verbose: false })
+
+    process.env.AGENTS_HERMES_CONFIG_PATH = secondConfig
+    await performSync({ projectRoot, check: false, verbose: false })
+    const cleanedFirst = parse(await readFile(firstConfig, 'utf8')) as HermesTestConfig
+    const appliedSecond = parse(await readFile(secondConfig, 'utf8')) as HermesTestConfig
+    expect(cleanedFirst.mcp_servers.manual).toBeDefined()
+    expect(cleanedFirst.mcp_servers.utilities).toBeUndefined()
+    expect(appliedSecond.mcp_servers.utilities.url).toBe('https://utilities.example/v2/mcp')
+
+    config.integrations.enabled = []
+    await saveAgentsConfig(projectRoot, config)
+    await performSync({ projectRoot, check: false, verbose: false })
+    const disabled = parse(await readFile(secondConfig, 'utf8')) as HermesTestConfig
+    expect(disabled.mcp_servers.manual).toBeDefined()
+    expect(disabled.mcp_servers.utilities).toBeUndefined()
+    expect(disabled.platform_toolsets.telegram).toEqual(['manual'])
+
+    const state = JSON.parse(await readFile(getProjectPaths(projectRoot).generatedHermesState, 'utf8')) as unknown
+    expect(state).toEqual({ configs: {} })
+  })
+})

--- a/tests/hermes.test.ts
+++ b/tests/hermes.test.ts
@@ -1,0 +1,130 @@
+import os from 'node:os'
+import path from 'node:path'
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { afterEach, describe, expect, it } from 'vitest'
+import { parse } from 'yaml'
+import {
+  mergeHermesConfig,
+  normalizeHermesManagedState,
+  resolveHermesConfigPath
+} from '../src/core/hermes.js'
+
+const tempDirs: string[] = []
+
+interface HermesTestConfig {
+  model?: { default?: string }
+  mcp_servers: Record<string, { url?: string } | undefined>
+  platform_toolsets: Record<string, string[]>
+}
+
+afterEach(async () => {
+  for (const dir of tempDirs.splice(0, tempDirs.length)) {
+    await rm(dir, { recursive: true, force: true })
+  }
+})
+
+describe('Hermes config integration', () => {
+  it('preserves comments, unrelated settings and unmanaged MCP servers', () => {
+    const source = `# operator comment
+model:
+  default: gpt-5
+mcp_servers:
+  manual:
+    url: https://manual.example/mcp
+  old-managed:
+    url: https://old.example/mcp
+platform_toolsets:
+  telegram: [web, old-managed]
+`
+
+    const merged = mergeHermesConfig(source, ['old-managed'], {
+      utilities: {
+        enabled: true,
+        url: 'https://utilities.example/mcp'
+      }
+    })
+    const parsed = parse(merged) as HermesTestConfig
+
+    expect(merged).toContain('# operator comment')
+    expect(parsed.model.default).toBe('gpt-5')
+    expect(parsed.mcp_servers.manual.url).toBe('https://manual.example/mcp')
+    expect(parsed.mcp_servers['old-managed']).toBeUndefined()
+    expect(parsed.mcp_servers.utilities.url).toBe('https://utilities.example/mcp')
+    expect(parsed.platform_toolsets.telegram).toEqual(['web', 'utilities'])
+  })
+
+  it('honors no_mcp and removes stale managed entries without adding replacements', () => {
+    const source = `mcp_servers:
+  stale:
+    command: stale-server
+platform_toolsets:
+  locked: [terminal, no_mcp, stale]
+`
+
+    const merged = mergeHermesConfig(source, ['stale'], {
+      utilities: { enabled: true, url: 'https://utilities.example/mcp' }
+    })
+    const parsed = parse(merged) as HermesTestConfig
+
+    expect(parsed.mcp_servers.stale).toBeUndefined()
+    expect(parsed.mcp_servers.utilities).toBeDefined()
+    expect(parsed.platform_toolsets.locked).toEqual(['terminal', 'no_mcp'])
+  })
+
+  it('uses HERMES_HOME by default and resolves one explicit workspace profile', async () => {
+    const home = await mkdtemp(path.join(os.tmpdir(), 'agents-hermes-home-'))
+    const activeHome = path.join(home, 'active-hermes')
+    tempDirs.push(home)
+    await mkdir(activeHome, { recursive: true })
+
+    const active = resolveHermesConfigPath({
+      profile: null,
+      env: { HERMES_HOME: activeHome },
+      homeDir: home
+    })
+    const named = resolveHermesConfigPath({
+      profile: 'home-lab',
+      env: { HERMES_HOME: activeHome },
+      homeDir: home
+    })
+
+    expect(active).toBe(path.join(activeHome, 'config.yaml'))
+    expect(named).toBe(path.join(home, '.hermes', 'profiles', 'home-lab', 'config.yaml'))
+  })
+
+  it('accepts an explicit config path override', async () => {
+    const home = await mkdtemp(path.join(os.tmpdir(), 'agents-hermes-home-'))
+    tempDirs.push(home)
+    const target = path.join(home, 'one.yaml')
+
+    const configPath = resolveHermesConfigPath({
+      profile: 'ignored-by-override',
+      env: { AGENTS_HERMES_CONFIG_PATH: target },
+      homeDir: home
+    })
+
+    expect(configPath).toBe(target)
+  })
+
+  it('rejects an unsafe profile name', () => {
+    expect(() => resolveHermesConfigPath({
+      profile: '../other-profile',
+      env: {},
+      homeDir: '/tmp/home'
+    })).toThrow(/Invalid Hermes profile/)
+  })
+
+  it('normalizes managed state defensively', () => {
+    expect(normalizeHermesManagedState({
+      configs: {
+        '/tmp/config.yaml': ['utilities', 'utilities', 42],
+        invalid: 'utilities'
+      }
+    })).toEqual({
+      configs: {
+        '/tmp/config.yaml': ['utilities']
+      }
+    })
+    expect(normalizeHermesManagedState(null)).toEqual({ configs: {} })
+  })
+})

--- a/tests/mcp-validation.test.ts
+++ b/tests/mcp-validation.test.ts
@@ -39,9 +39,9 @@ describe('mcp validation', () => {
     )
   })
 
-  it('parses target options including claude_desktop, windsurf and opencode', () => {
-    const targets = parseTargetOptions(['claude_desktop,windsurf,opencode'])
-    expect(targets).toEqual(['claude_desktop', 'windsurf', 'opencode'])
+  it('parses target options including claude_desktop, windsurf, opencode and hermes', () => {
+    const targets = parseTargetOptions(['claude_desktop,windsurf,opencode,hermes'])
+    expect(targets).toEqual(['claude_desktop', 'windsurf', 'opencode', 'hermes'])
   })
 
   it('rejects reserved server names', () => {

--- a/tests/renderers.test.ts
+++ b/tests/renderers.test.ts
@@ -81,7 +81,11 @@ describe('renderers', () => {
 
     const first = mergeCodexConfig(unmanaged, firstGenerated)
     const second = mergeCodexConfig(first, secondGenerated)
+    const firstBegin = first.indexOf(CODEX_MANAGED_MCP_BEGIN)
+    const firstEnd = first.indexOf('\n', first.indexOf(CODEX_MANAGED_MCP_END))
 
+    expect(first.slice(0, firstBegin)).toBe(unmanaged)
+    expect(first.slice(firstEnd + 1)).toBe('')
     expect(second.slice(0, second.indexOf(CODEX_MANAGED_MCP_BEGIN))).toBe(
       first.slice(0, first.indexOf(CODEX_MANAGED_MCP_BEGIN)),
     )
@@ -89,6 +93,121 @@ describe('renderers', () => {
     expect(second).not.toContain('"first"')
     expect(second.match(/# BEGIN agents-sync managed MCP/g)).toHaveLength(1)
     expect(() => TOML.parse(second)).not.toThrow()
+  })
+
+  it('preserves byte-exact unmanaged content before and after an existing managed block', () => {
+    const before = '# Before block\nmodel = "gpt-5.6-sol"\n\n'
+    const after = '\n# After block\n[features]\nweb_search = true\n'
+    const existing = [
+      before,
+      CODEX_MANAGED_MCP_BEGIN,
+      '\n[mcp_servers."executor"]\ncommand = "old"\n',
+      CODEX_MANAGED_MCP_END,
+      after
+    ].join('')
+    const generated = renderCodexToml([{
+      name: 'executor',
+      transport: 'stdio',
+      command: 'executor',
+      args: ['mcp']
+    }]).content
+
+    const merged = mergeCodexConfig(existing, generated)
+    const begin = merged.indexOf(CODEX_MANAGED_MCP_BEGIN)
+    const end = merged.indexOf(CODEX_MANAGED_MCP_END) + CODEX_MANAGED_MCP_END.length
+
+    expect(merged.slice(0, begin)).toBe(before)
+    expect(merged.slice(end)).toBe(after)
+    expect(merged).toContain('command = "executor"')
+    expect(merged).not.toContain('command = "old"')
+  })
+
+  it.each(['"""', "'''"])(
+    'does not treat marker lines inside a %s TOML string as ownership markers',
+    (delimiter) => {
+    const unmanaged = [
+      `prompt = ${delimiter}`,
+      CODEX_MANAGED_MCP_BEGIN,
+      'This text belongs to the prompt.',
+      CODEX_MANAGED_MCP_END,
+      delimiter,
+      ''
+    ].join('\n')
+
+    const merged = mergeCodexConfig(unmanaged, renderCodexToml([]).content)
+
+    expect(merged.slice(0, unmanaged.length)).toBe(unmanaged)
+    expect(merged).toContain([
+      `prompt = ${delimiter}`,
+      CODEX_MANAGED_MCP_BEGIN,
+      'This text belongs to the prompt.',
+      CODEX_MANAGED_MCP_END,
+      delimiter
+    ].join('\n'))
+    expect(merged.match(/# BEGIN agents-sync managed MCP/g)).toHaveLength(2)
+    expect(() => TOML.parse(merged)).not.toThrow()
+    },
+  )
+
+  it('does not treat marker-like longer comment lines as ownership markers', () => {
+    const unmanaged = [
+      `# Documentation mentions ${CODEX_MANAGED_MCP_BEGIN}`,
+      `# Documentation mentions ${CODEX_MANAGED_MCP_END}`,
+      `  ${CODEX_MANAGED_MCP_BEGIN}`,
+      `  ${CODEX_MANAGED_MCP_END}`,
+      'model = "gpt-5.6-sol"',
+      ''
+    ].join('\n')
+
+    const merged = mergeCodexConfig(unmanaged, renderCodexToml([]).content)
+
+    expect(merged.slice(0, unmanaged.length)).toBe(unmanaged)
+    expect(merged).toContain(`# Documentation mentions ${CODEX_MANAGED_MCP_BEGIN}`)
+    expect(merged).toContain(`# Documentation mentions ${CODEX_MANAGED_MCP_END}`)
+    expect(merged).toContain(`  ${CODEX_MANAGED_MCP_BEGIN}`)
+    expect(merged).toContain(`  ${CODEX_MANAGED_MCP_END}`)
+    expect(() => TOML.parse(merged)).not.toThrow()
+  })
+
+  it('does not treat marker substrings in escaped basic string values as ownership markers', () => {
+    const unmanaged = [
+      `begin_note = "escaped quote: \\"; marker: ${CODEX_MANAGED_MCP_BEGIN}"`,
+      `end_note = "marker: ${CODEX_MANAGED_MCP_END}"`,
+      ''
+    ].join('\n')
+
+    const merged = mergeCodexConfig(unmanaged, renderCodexToml([]).content)
+
+    expect(merged.slice(0, unmanaged.length)).toBe(unmanaged)
+    expect(merged).toContain(`escaped quote: \\"; marker: ${CODEX_MANAGED_MCP_BEGIN}`)
+    expect(() => TOML.parse(merged)).not.toThrow()
+  })
+
+  it('preserves CRLF outside a managed block and uses it for the replacement block', () => {
+    const before = 'model = "gpt-5.6-sol"\r\n\r\n'
+    const after = '\r\n# After\r\nweb_search = true\r\n'
+    const existing = [
+      before,
+      CODEX_MANAGED_MCP_BEGIN,
+      '\r\n[mcp_servers."executor"]\r\ncommand = "old"\r\n',
+      CODEX_MANAGED_MCP_END,
+      after
+    ].join('')
+
+    const merged = mergeCodexConfig(existing, renderCodexToml([{
+      name: 'executor',
+      transport: 'stdio',
+      command: 'executor',
+      args: ['mcp']
+    }]).content)
+    const begin = merged.indexOf(CODEX_MANAGED_MCP_BEGIN)
+    const end = merged.indexOf(CODEX_MANAGED_MCP_END) + CODEX_MANAGED_MCP_END.length
+    const managed = merged.slice(begin, end)
+
+    expect(merged.slice(0, begin)).toBe(before)
+    expect(merged.slice(end)).toBe(after)
+    expect(managed).not.toMatch(/(?<!\r)\n/)
+    expect(() => TOML.parse(merged)).not.toThrow()
   })
 
   it.each([

--- a/tests/renderers.test.ts
+++ b/tests/renderers.test.ts
@@ -12,6 +12,7 @@ import {
   renderWindsurfMcp
 } from '../src/core/renderers.js'
 import { toManagedClaudeDesktopName } from '../src/core/claudeDesktop.js'
+import { buildHermesPayload } from '../src/integrations/hermes.js'
 import type { ResolvedMcpServer } from '../src/types.js'
 
 const projectRoot = '/tmp/agents-renderers'
@@ -189,6 +190,31 @@ describe('renderers', () => {
     expect(rendered.mcpServers['filesystem']).not.toHaveProperty('type')
   })
 
+  it('renders Hermes-native stdio, HTTP and SSE definitions', () => {
+    const rendered = buildHermesPayload(servers)
+
+    expect(rendered.mcpServers).toMatchObject({
+      filesystem: {
+        command: 'npx',
+        args: ['-y', '@modelcontextprotocol/server-filesystem', '/tmp/project'],
+        enabled: true
+      },
+      'http-tools': {
+        url: 'https://example.com/mcp',
+        headers: {
+          Authorization: 'Bearer token'
+        },
+        enabled: true
+      },
+      'sse-tools': {
+        url: 'https://example.com/sse',
+        transport: 'sse',
+        enabled: true
+      }
+    })
+    expect(rendered.warnings).toEqual([])
+  })
+
   describe('cwd propagation', () => {
     const serversWithCwd: ResolvedMcpServer[] = [
       {
@@ -204,6 +230,13 @@ describe('renderers', () => {
       const rendered = renderCodexToml(serversWithCwd)
       expect(rendered.content).toContain('cwd = "/abs/path/to/project"')
       expect(() => TOML.parse(rendered.content)).not.toThrow()
+    })
+
+    it('warns when Hermes cannot represent a stdio cwd', () => {
+      const rendered = buildHermesPayload(serversWithCwd)
+
+      expect(rendered.mcpServers['project-server']).not.toHaveProperty('cwd')
+      expect(rendered.warnings.join(' ')).toContain('does not support cwd')
     })
 
     it('gemini includes cwd for stdio server', () => {

--- a/tests/renderers.test.ts
+++ b/tests/renderers.test.ts
@@ -12,6 +12,11 @@ import {
   renderWindsurfMcp
 } from '../src/core/renderers.js'
 import { toManagedClaudeDesktopName } from '../src/core/claudeDesktop.js'
+import {
+  CODEX_MANAGED_MCP_BEGIN,
+  CODEX_MANAGED_MCP_END,
+  mergeCodexConfig
+} from '../src/core/codexConfig.js'
 import { buildHermesPayload } from '../src/integrations/hermes.js'
 import type { ResolvedMcpServer } from '../src/types.js'
 
@@ -50,6 +55,51 @@ describe('renderers', () => {
     expect(rendered.content).toContain('[mcp_servers."sse-tools"]')
     expect(rendered.warnings.join(' ')).toContain('legacy sse transport')
     expect(() => TOML.parse(rendered.content)).not.toThrow()
+  })
+
+  it('replaces only the agents-sync managed Codex block', () => {
+    const unmanaged = [
+      '# Project comment',
+      'model = "gpt-5.6-sol"',
+      '',
+      '[mcp_servers.node_repl]',
+      'enabled = false',
+      ''
+    ].join('\n')
+    const firstGenerated = renderCodexToml([{
+      name: 'executor',
+      transport: 'stdio',
+      command: 'executor',
+      args: ['mcp', '--scope', 'first']
+    }]).content
+    const secondGenerated = renderCodexToml([{
+      name: 'executor',
+      transport: 'stdio',
+      command: 'executor',
+      args: ['mcp', '--scope', 'second']
+    }]).content
+
+    const first = mergeCodexConfig(unmanaged, firstGenerated)
+    const second = mergeCodexConfig(first, secondGenerated)
+
+    expect(second.slice(0, second.indexOf(CODEX_MANAGED_MCP_BEGIN))).toBe(
+      first.slice(0, first.indexOf(CODEX_MANAGED_MCP_BEGIN)),
+    )
+    expect(second).toContain('"second"')
+    expect(second).not.toContain('"first"')
+    expect(second.match(/# BEGIN agents-sync managed MCP/g)).toHaveLength(1)
+    expect(() => TOML.parse(second)).not.toThrow()
+  })
+
+  it.each([
+    `${CODEX_MANAGED_MCP_BEGIN}\n`,
+    `${CODEX_MANAGED_MCP_END}\n`,
+    `${CODEX_MANAGED_MCP_BEGIN}\n${CODEX_MANAGED_MCP_BEGIN}\n${CODEX_MANAGED_MCP_END}\n`,
+    `${CODEX_MANAGED_MCP_BEGIN}\n${CODEX_MANAGED_MCP_END}\n${CODEX_MANAGED_MCP_END}\n`
+  ])('rejects a malformed agents-sync managed Codex block', (existing) => {
+    expect(() => mergeCodexConfig(existing, renderCodexToml([]).content)).toThrow(
+      /malformed agents-sync managed MCP block/,
+    )
   })
 
   it('renders gemini server map for stdio and http', () => {

--- a/tests/start-sync.integration.test.ts
+++ b/tests/start-sync.integration.test.ts
@@ -108,13 +108,159 @@ describe('start + sync flow', () => {
     expect(configAfterNoopSync.lastSync).toBe(configAfterDriftSync.lastSync)
 
     await writeFile(path.join(projectRoot, '.codex', 'config.toml'), '', 'utf8')
+    const codexBeforeCheck = await readFile(path.join(projectRoot, '.codex', 'config.toml'), 'utf8')
     const check = await performSync({ projectRoot, check: true, verbose: false })
     expect(check.changed).toContain('.codex/config.toml')
+    expect(await readFile(path.join(projectRoot, '.codex', 'config.toml'), 'utf8')).toBe(codexBeforeCheck)
 
     const configAfterCheck = JSON.parse(
       await readFile(path.join(projectRoot, '.agents', 'agents.json'), 'utf8'),
     ) as { lastSync: string | null }
     expect(configAfterCheck.lastSync).toBe(configAfterNoopSync.lastSync)
+  })
+
+  it('preserves unmanaged Codex settings while adding managed MCP servers', async () => {
+    const projectRoot = await mkdtemp(path.join(os.tmpdir(), 'agents-codex-merge-'))
+    const codexDir = await mkdtemp(path.join(os.tmpdir(), 'agents-codex-global-'))
+    tempDirs.push(projectRoot, codexDir)
+
+    process.env.AGENTS_CODEX_CONFIG_PATH = path.join(codexDir, 'config.toml')
+    process.env.PATH = '/dev/null'
+
+    await runStart({
+      projectRoot,
+      nonInteractive: true,
+      yes: true
+    })
+
+    const codexConfigPath = path.join(projectRoot, '.codex', 'config.toml')
+    const unmanagedCodexConfig = [
+      '# Project-owned Codex settings',
+      'model = "gpt-5.6-sol"',
+      '',
+      '[mcp_servers.node_repl]',
+      'enabled = false',
+      ''
+    ].join('\n')
+    await writeFile(codexConfigPath, unmanagedCodexConfig, 'utf8')
+
+    const config = await loadAgentsConfig(projectRoot)
+    config.mcp.servers = {
+      executor: {
+        transport: 'stdio',
+        command: 'executor',
+        args: ['mcp', '--scope', 'coi_chief_of_staff'],
+        targets: ['codex']
+      }
+    }
+    await saveAgentsConfig(projectRoot, config)
+
+    await performSync({ projectRoot, check: false, verbose: false })
+
+    const merged = await readFile(codexConfigPath, 'utf8')
+    expect(merged).toContain('# Project-owned Codex settings')
+    expect(merged).toContain('model = "gpt-5.6-sol"')
+    expect(merged).toContain('[mcp_servers.node_repl]')
+    expect(merged).toContain('enabled = false')
+    expect(merged).toContain('# BEGIN agents-sync managed MCP')
+    expect(merged).toContain('[mcp_servers."executor"]')
+    expect(merged).toContain('# END agents-sync managed MCP')
+    expect(() => TOML.parse(merged)).not.toThrow()
+  })
+
+  it('changes only the managed Codex block on a second sync', async () => {
+    const projectRoot = await mkdtemp(path.join(os.tmpdir(), 'agents-codex-resync-'))
+    const codexDir = await mkdtemp(path.join(os.tmpdir(), 'agents-codex-global-'))
+    tempDirs.push(projectRoot, codexDir)
+
+    process.env.AGENTS_CODEX_CONFIG_PATH = path.join(codexDir, 'config.toml')
+    process.env.PATH = '/dev/null'
+
+    await runStart({
+      projectRoot,
+      nonInteractive: true,
+      yes: true
+    })
+
+    const codexConfigPath = path.join(projectRoot, '.codex', 'config.toml')
+    const unmanagedCodexConfig = [
+      '# This comment and the settings below are project-owned.',
+      'model = "gpt-5.6-sol"',
+      '',
+      '[mcp_servers.node_repl]',
+      'enabled = false',
+      ''
+    ].join('\n')
+    await writeFile(codexConfigPath, unmanagedCodexConfig, 'utf8')
+
+    const config = await loadAgentsConfig(projectRoot)
+    config.mcp.servers = {
+      executor: {
+        transport: 'stdio',
+        command: 'executor',
+        args: ['mcp', '--scope', 'first'],
+        targets: ['codex']
+      }
+    }
+    await saveAgentsConfig(projectRoot, config)
+    await performSync({ projectRoot, check: false, verbose: false })
+
+    const first = await readFile(codexConfigPath, 'utf8')
+    config.mcp.servers.executor.args = ['mcp', '--scope', 'second']
+    await saveAgentsConfig(projectRoot, config)
+    await performSync({ projectRoot, check: false, verbose: false })
+
+    const second = await readFile(codexConfigPath, 'utf8')
+    const managedStart = '# BEGIN agents-sync managed MCP'
+    const managedEnd = '# END agents-sync managed MCP'
+    const firstStart = first.indexOf(managedStart)
+    const secondStart = second.indexOf(managedStart)
+    const firstEnd = first.indexOf(managedEnd) + managedEnd.length
+    const secondEnd = second.indexOf(managedEnd) + managedEnd.length
+
+    expect(firstStart).toBeGreaterThanOrEqual(0)
+    expect(secondStart).toBeGreaterThanOrEqual(0)
+    expect(first.slice(0, firstStart)).toBe(second.slice(0, secondStart))
+    expect(first.slice(firstEnd)).toBe(second.slice(secondEnd))
+    expect(second.match(/# BEGIN agents-sync managed MCP/g)).toHaveLength(1)
+    expect(second).not.toContain('"first"')
+    expect(second).toContain('"second"')
+    expect(() => TOML.parse(second)).not.toThrow()
+  })
+
+  it.each([false, true])('rejects invalid existing Codex TOML without overwriting it (check: %s)', async (check) => {
+    const projectRoot = await mkdtemp(path.join(os.tmpdir(), 'agents-codex-invalid-project-'))
+    const codexDir = await mkdtemp(path.join(os.tmpdir(), 'agents-codex-global-'))
+    tempDirs.push(projectRoot, codexDir)
+
+    process.env.AGENTS_CODEX_CONFIG_PATH = path.join(codexDir, 'config.toml')
+    process.env.PATH = '/dev/null'
+
+    await runStart({
+      projectRoot,
+      nonInteractive: true,
+      yes: true
+    })
+
+    const codexConfigPath = path.join(projectRoot, '.codex', 'config.toml')
+    const invalidCodexConfig = 'model = "unterminated\n'
+    await writeFile(codexConfigPath, invalidCodexConfig, 'utf8')
+
+    const config = await loadAgentsConfig(projectRoot)
+    config.mcp.servers = {
+      executor: {
+        transport: 'stdio',
+        command: 'executor',
+        args: ['mcp'],
+        targets: ['codex']
+      }
+    }
+    await saveAgentsConfig(projectRoot, config)
+
+    await expect(
+      performSync({ projectRoot, check, verbose: false }),
+    ).rejects.toThrow(/invalid existing Codex TOML/i)
+    expect(await readFile(codexConfigPath, 'utf8')).toBe(invalidCodexConfig)
   })
 
   it('keeps lastSync stable after safe reset when sources did not change', async () => {

--- a/tests/status.command.test.ts
+++ b/tests/status.command.test.ts
@@ -11,10 +11,12 @@ import * as shell from '../src/core/shell.js'
 const tempDirs: string[] = []
 let previousWindsurfMcpPath: string | undefined
 let previousClaudeDesktopConfigPath: string | undefined
+let previousHermesConfigPath: string | undefined
 
 beforeEach(() => {
   previousWindsurfMcpPath = process.env.AGENTS_WINDSURF_MCP_PATH
   previousClaudeDesktopConfigPath = process.env.AGENTS_CLAUDE_DESKTOP_CONFIG_PATH
+  previousHermesConfigPath = process.env.AGENTS_HERMES_CONFIG_PATH
 })
 
 afterEach(async () => {
@@ -28,6 +30,11 @@ afterEach(async () => {
     delete process.env.AGENTS_CLAUDE_DESKTOP_CONFIG_PATH
   } else {
     process.env.AGENTS_CLAUDE_DESKTOP_CONFIG_PATH = previousClaudeDesktopConfigPath
+  }
+  if (previousHermesConfigPath === undefined) {
+    delete process.env.AGENTS_HERMES_CONFIG_PATH
+  } else {
+    process.env.AGENTS_HERMES_CONFIG_PATH = previousHermesConfigPath
   }
   for (const dir of tempDirs.splice(0, tempDirs.length)) {
     await rm(dir, { recursive: true, force: true })
@@ -233,6 +240,33 @@ describe('status command', () => {
     const parsed = JSON.parse(output) as { files: Record<string, boolean>; probes: Record<string, string> }
     expect(parsed.files['.agents/mcp_config.json']).toBeUndefined()
     expect(parsed.probes.antigravity).toContain('MCP sync disabled')
+  })
+
+  it('reports the one Hermes config owned by the workspace', async () => {
+    const projectRoot = await mkdtemp(path.join(os.tmpdir(), 'agents-status-'))
+    const hermesRoot = await mkdtemp(path.join(os.tmpdir(), 'agents-hermes-status-'))
+    tempDirs.push(projectRoot, hermesRoot)
+    process.env.AGENTS_HERMES_CONFIG_PATH = path.join(hermesRoot, 'config.yaml')
+
+    await runInit({ projectRoot, force: true })
+    const config = await loadAgentsConfig(projectRoot)
+    config.integrations.enabled = ['hermes']
+    config.mcp.servers = {
+      utilities: {
+        transport: 'http',
+        url: 'https://utilities.example/mcp',
+        targets: ['hermes']
+      }
+    }
+    await saveAgentsConfig(projectRoot, config)
+    await performSync({ projectRoot, check: false, verbose: false })
+
+    const output = await captureStdout(async () => {
+      await runStatus({ projectRoot, json: true, verbose: false, fast: false })
+    })
+    const parsed = JSON.parse(output) as { files: Record<string, boolean>; probes: Record<string, string> }
+    expect(parsed.files[process.env.AGENTS_HERMES_CONFIG_PATH]).toBe(true)
+    expect(parsed.probes.hermes).toContain('1 managed server(s) configured')
   })
 })
 


### PR DESCRIPTION
## Summary

- Replace only the deterministic Agent Sync-managed MCP section instead of rewriting the complete Codex project config.
- Preserve unmanaged settings such as model selection and disabled built-in MCP servers across repeated syncs.
- Reject malformed existing TOML without overwriting the user file and harden managed-block detection.

## Verification

- Full suite: 216/216 tests passed.
- Focused sync and renderer tests passed.
- ESLint, typecheck, and build passed.
- Clean v0.8.9 patch application and repeated sync behavior were verified.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Новые возможности**
  * Добавлена интеграция Hermes Agent для синхронизации MCP-серверов.
  * Поддержан выбор профиля Hermes и YAML-конфигурация с сохранением неуправляемых настроек.
  * Добавлены синхронизация, проверка дрейфа, статус и диагностика Hermes.
  * Улучшено объединение управляемых настроек Codex без перезаписи пользовательских данных.

* **Документация**
  * Обновлены README, CHANGELOG и руководства по поддерживаемым интеграциям и настройке Hermes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->