### PR TITLE
release: 0.8.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,12 +15,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Support for global installation: all CLI commands accept `--global` / `-g` (or running from `$HOME`), syncing MCP servers and skills machine-wide.
 - OpenCode global configuration support: when run in global mode, OpenCode config is materialized at `~/.config/opencode/opencode.json` (or `$XDG_CONFIG_HOME/opencode/opencode.json`), preserving non-MCP settings and automatically migrating legacy `~/opencode.json`.
+- New CLI command: `agents skills list` (alias `agents skills ls`) to inspect and list discovered skills, paths, and descriptions.
 - Automatic tilde expansion (`~` and `~/...`) for CLI `--path` arguments.
 
 ### Changed
 
 - `agents doctor` now detects misplaced legacy `~/opencode.json` files and validates global OpenCode configuration paths when run in home directory mode.
 - `agents status` labels the OpenCode configuration as `~/.config/opencode/opencode.json` when running in global mode.
+
+### Fixed
+
+- Updated `@humanfs/node` to `0.16.8` to fix path traversal security vulnerability during recursive copies (Dependabot alert #13 / GHSA-p498-v437-472g).
 
 ## [0.8.10] - 2026-08-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- No changes yet.
+### Added
+
+- Support for global installation: all CLI commands accept `--global` / `-g` (or running from `$HOME`), syncing MCP servers and skills machine-wide.
+- OpenCode global configuration support: when run in global mode, OpenCode config is materialized at `~/.config/opencode/opencode.json` (or `$XDG_CONFIG_HOME/opencode/opencode.json`), preserving non-MCP settings and automatically migrating legacy `~/opencode.json`.
+- Automatic tilde expansion (`~` and `~/...`) for CLI `--path` arguments.
+
+### Changed
+
+- `agents doctor` now detects misplaced legacy `~/opencode.json` files and validates global OpenCode configuration paths when run in home directory mode.
+- `agents status` labels the OpenCode configuration as `~/.config/opencode/opencode.json` when running in global mode.
 
 ## [0.8.10] - 2026-08-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- No changes yet.
+
+## [0.8.11] - 2026-09-04
+
 ### Added
 
 - Support for global installation: all CLI commands accept `--global` / `-g` (or running from `$HOME`), syncing MCP servers and skills machine-wide.

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ Add a server once in `.agents/agents.json`, then run `agents sync` to materializ
     <td align="center">✅</td>
     <td align="center">✅</td>
     <td align="center">✅</td>
-    <td>Writes project <code>opencode.json</code> (or global <code>~/.config/opencode/opencode.json</code>)</td>
+    <td>Writes project <code>opencode.json</code> (or global <code>~/.config/opencode/opencode.json</code> / <code>$XDG_CONFIG_HOME/opencode/opencode.json</code>)</td>
   </tr>
   <tr>
     <td><strong>Junie</strong></td>

--- a/README.md
+++ b/README.md
@@ -255,6 +255,13 @@ your-project/
 | `agents mcp test` | Validate server definitions |
 | `agents mcp test --runtime` | Live connectivity check via tool CLIs |
 
+### Skills Management
+
+| Command | Description |
+|:--------|:------------|
+| `agents skills list` | List configured skills across `.agents/skills/` (`ls` alias supported) |
+| `agents skills list -g` | List global skills in `~/.agents/skills/` |
+
 ### Integrations
 
 | Command | Description |

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ Add a server once in `.agents/agents.json`, then run `agents sync` to materializ
     <td align="center">✅</td>
     <td align="center">✅</td>
     <td align="center">✅</td>
-    <td>Writes project <code>opencode.json</code> (<code>mcp</code> block)</td>
+    <td>Writes project <code>opencode.json</code> (or global <code>~/.config/opencode/opencode.json</code>)</td>
   </tr>
   <tr>
     <td><strong>Junie</strong></td>
@@ -263,6 +263,22 @@ your-project/
 | `agents disconnect --llm codex` | Disable integrations |
 | `agents reset` | Remove generated files, keep `.agents/` |
 | `agents reset --hard` | Full cleanup — removes all agents-managed setup |
+
+### Global Usage (`--global` / `-g`)
+
+Run any command with `--global` (or `-g`, or from `$HOME`) to manage MCP servers and skills across your entire system:
+
+```bash
+agents init -g
+agents connect -g --llm opencode,codex,cursor
+agents sync -g
+```
+
+In global mode:
+- Machine-wide source of truth lives in `~/.agents/agents.json`.
+- OpenCode configuration is materialized at `~/.config/opencode/opencode.json` (or `$XDG_CONFIG_HOME/opencode/opencode.json`).
+- All tools (Codex, Cursor, Gemini, Copilot, Antigravity, Claude) sync to their standard user-level configuration directories.
+- CLI `--path` arguments automatically expand `~` and `~/...`.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -685,25 +685,39 @@
       }
     },
     "node_modules/@humanfs/core": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
-      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
       "dev": true,
       "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
       "engines": {
         "node": ">=18.18.0"
       }
     },
     "node_modules/@humanfs/node": {
-      "version": "0.16.7",
-      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
-      "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@humanfs/core": "^0.19.1",
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
         "@humanwhocodes/retry": "^0.4.0"
       },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=18.18.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@agents-dev/cli",
-  "version": "0.8.10",
+  "version": "0.8.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@agents-dev/cli",
-      "version": "0.8.10",
+      "version": "0.8.11",
       "license": "Apache-2.0",
       "dependencies": {
         "@clack/prompts": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agents-dev/cli",
-  "version": "0.8.10",
+  "version": "0.8.11",
   "description": "One config to rule them all — sync MCP servers, skills, and AGENTS.md across Codex, Claude Code/Desktop, Gemini CLI, Cursor, Copilot VS Code/CLI, Antigravity, Windsurf, OpenCode, and Junie.",
   "main": "dist/cli.js",
   "scripts": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -22,18 +22,24 @@ import { CLI_VERSION } from './core/version.js'
 import { getHomeDir } from './core/paths.js'
 import * as ui from './core/ui.js'
 
+/** Resolve the effective project directory based on CLI options (`--path` or `--global`). */
 function resolveTargetDirectory(opts: { path?: string; global?: boolean }): string {
   if (opts.global) return getHomeDir()
   return resolvePath(opts.path)
 }
 
+/** Resolve and expand a target path, supporting tilde (`~` and `~/...`). */
 function resolvePath(input: string | undefined): string {
-  if (!input) return process.cwd()
-  if (input === '~') return getHomeDir()
-  if (input.startsWith('~/') || input.startsWith('~\\')) {
-    return path.join(getHomeDir(), input.slice(2))
+  if (input === undefined) return process.cwd()
+  const trimmed = input.trim()
+  if (trimmed.length === 0) {
+    throw new Error('Target path cannot be empty.')
   }
-  return path.resolve(input)
+  if (trimmed === '~') return getHomeDir()
+  if (trimmed.startsWith('~/') || trimmed.startsWith('~\\')) {
+    return path.join(getHomeDir(), trimmed.slice(2))
+  }
+  return path.resolve(trimmed)
 }
 
 async function main(): Promise<void> {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -18,10 +18,21 @@ import { runWatch } from './commands/watch.js'
 import { CancelledError } from './core/errors.js'
 import { maybeNotifyAboutUpdate } from './core/updateCheck.js'
 import { CLI_VERSION } from './core/version.js'
+import { getHomeDir } from './core/paths.js'
 import * as ui from './core/ui.js'
 
+function resolveTargetDirectory(opts: { path?: string; global?: boolean }): string {
+  if (opts.global) return getHomeDir()
+  return resolvePath(opts.path)
+}
+
 function resolvePath(input: string | undefined): string {
-  return path.resolve(input ?? process.cwd())
+  if (!input) return process.cwd()
+  if (input === '~') return getHomeDir()
+  if (input.startsWith('~/') || input.startsWith('~\\')) {
+    return path.join(getHomeDir(), input.slice(2))
+  }
+  return path.resolve(input)
 }
 
 async function main(): Promise<void> {
@@ -34,14 +45,14 @@ async function main(): Promise<void> {
     .option('--no-update-check', 'Disable update availability checks')
 
   program.hook('preAction', async (_thisCommand, actionCommand) => {
-    const opts = actionCommand.optsWithGlobals() as { updateCheck?: boolean; path?: string }
+    const opts = actionCommand.optsWithGlobals() as { updateCheck?: boolean; path?: string; global?: boolean }
     if (opts.updateCheck === false) return
     if (process.argv.includes('--no-update-check')) return
     if (process.env.AGENTS_NO_UPDATE_CHECK === '1') return
     if (process.argv.includes('--json') || process.argv.includes('--quiet')) return
     if (actionCommand.name() === 'update') return
 
-    const projectRoot = resolvePath(typeof opts.path === 'string' ? opts.path : process.cwd())
+    const projectRoot = resolveTargetDirectory(opts)
     void maybeNotifyAboutUpdate({
       currentVersion: CLI_VERSION,
       projectRoot
@@ -52,13 +63,14 @@ async function main(): Promise<void> {
     .command('start')
     .description('Guided setup wizard: init + integrations + MCP + skills + sync')
     .option('--path <dir>', 'Target project directory', process.cwd())
+    .option('-g, --global', 'Target global user home directory (~/.agents)', false)
     .option('--non-interactive', 'Disable interactive wizard and use defaults', false)
     .option('--yes', 'Auto-confirm defaults (non-interactive)', false)
     .option('--reinit', 'Reinitialize existing .agents/agents.json with wizard/default values', false)
     .option('--inject-docs', 'Insert agents usage section into README/CONTRIBUTING when starting', false)
-    .action(async (opts: { path: string; nonInteractive: boolean; yes: boolean; reinit: boolean; injectDocs: boolean }) => {
+    .action(async (opts: { path: string; global: boolean; nonInteractive: boolean; yes: boolean; reinit: boolean; injectDocs: boolean }) => {
       await runStart({
-        projectRoot: resolvePath(opts.path),
+        projectRoot: resolveTargetDirectory(opts),
         nonInteractive: Boolean(opts.nonInteractive),
         yes: Boolean(opts.yes),
         reinit: Boolean(opts.reinit),
@@ -70,10 +82,11 @@ async function main(): Promise<void> {
     .command('init')
     .description('Initialize .agents scaffold (without full guided setup)')
     .option('--path <dir>', 'Target project directory', process.cwd())
+    .option('-g, --global', 'Target global user home directory (~/.agents)', false)
     .option('--force', 'Overwrite scaffold files when possible', false)
-    .action(async (opts: { path: string; force: boolean }) => {
+    .action(async (opts: { path: string; global: boolean; force: boolean }) => {
       await runInit({
-        projectRoot: resolvePath(opts.path),
+        projectRoot: resolveTargetDirectory(opts),
         force: Boolean(opts.force)
       })
     })
@@ -82,12 +95,13 @@ async function main(): Promise<void> {
     .command('connect')
     .description('Enable LLM integrations and sync')
     .option('--path <dir>', 'Target project directory', process.cwd())
+    .option('-g, --global', 'Target global user home directory (~/.agents)', false)
     .option('--llm <list>', 'Comma-separated list: codex,claude,claude_desktop,gemini,copilot_vscode,copilot_cli,cursor,antigravity,windsurf,opencode,junie')
     .option('--interactive', 'Open interactive selector')
     .option('--verbose', 'Print detailed sync output', false)
-    .action(async (opts: { path: string; llm?: string; interactive?: boolean; verbose: boolean }) => {
+    .action(async (opts: { path: string; global: boolean; llm?: string; interactive?: boolean; verbose: boolean }) => {
       await runConnect({
-        projectRoot: resolvePath(opts.path),
+        projectRoot: resolveTargetDirectory(opts),
         llm: opts.llm,
         interactive: opts.interactive ?? !opts.llm,
         verbose: Boolean(opts.verbose)
@@ -98,12 +112,13 @@ async function main(): Promise<void> {
     .command('disconnect')
     .description('Disable LLM integrations and sync')
     .option('--path <dir>', 'Target project directory', process.cwd())
+    .option('-g, --global', 'Target global user home directory (~/.agents)', false)
     .option('--llm <list>', 'Comma-separated list: codex,claude,claude_desktop,gemini,copilot_vscode,copilot_cli,cursor,antigravity,windsurf,opencode,junie')
     .option('--interactive', 'Open interactive selector')
     .option('--verbose', 'Print detailed sync output', false)
-    .action(async (opts: { path: string; llm?: string; interactive?: boolean; verbose: boolean }) => {
+    .action(async (opts: { path: string; global: boolean; llm?: string; interactive?: boolean; verbose: boolean }) => {
       await runDisconnect({
-        projectRoot: resolvePath(opts.path),
+        projectRoot: resolveTargetDirectory(opts),
         llm: opts.llm,
         interactive: opts.interactive ?? !opts.llm,
         verbose: Boolean(opts.verbose)
@@ -114,11 +129,12 @@ async function main(): Promise<void> {
     .command('sync')
     .description('Generate and materialize configs from .agents source-of-truth')
     .option('--path <dir>', 'Target project directory', process.cwd())
+    .option('-g, --global', 'Target global user home directory (~/.agents)', false)
     .option('--check', 'Check for pending changes without writing files', false)
     .option('--verbose', 'Print detailed sync output', false)
-    .action(async (opts: { path: string; check: boolean; verbose: boolean }) => {
+    .action(async (opts: { path: string; global: boolean; check: boolean; verbose: boolean }) => {
       await runSync({
-        projectRoot: resolvePath(opts.path),
+        projectRoot: resolveTargetDirectory(opts),
         check: Boolean(opts.check),
         verbose: Boolean(opts.verbose)
       })
@@ -128,12 +144,13 @@ async function main(): Promise<void> {
     .command('watch')
     .description('Watch .agents source files and auto-run sync on changes')
     .option('--path <dir>', 'Target project directory', process.cwd())
+    .option('-g, --global', 'Target global user home directory (~/.agents)', false)
     .option('--interval <ms>', 'Polling interval in milliseconds', '1200')
     .option('--once', 'Run one sync pass and exit', false)
     .option('--quiet', 'Reduce periodic output', false)
-    .action(async (opts: { path: string; interval: string; once: boolean; quiet: boolean }) => {
+    .action(async (opts: { path: string; global: boolean; interval: string; once: boolean; quiet: boolean }) => {
       await runWatch({
-        projectRoot: resolvePath(opts.path),
+        projectRoot: resolveTargetDirectory(opts),
         intervalMs: Number.parseInt(opts.interval, 10),
         once: Boolean(opts.once),
         quiet: Boolean(opts.quiet)
@@ -144,12 +161,13 @@ async function main(): Promise<void> {
     .command('status')
     .description('Show enabled integrations, MCP servers, files and probes')
     .option('--path <dir>', 'Target project directory', process.cwd())
+    .option('-g, --global', 'Target global user home directory (~/.agents)', false)
     .option('--json', 'Output machine-readable JSON', false)
     .option('--verbose', 'Show full files/probes breakdown', false)
     .option('--fast', 'Skip external CLI probes for quicker output', false)
-    .action(async (opts: { path: string; json: boolean; verbose: boolean; fast: boolean }) => {
+    .action(async (opts: { path: string; global: boolean; json: boolean; verbose: boolean; fast: boolean }) => {
       await runStatus({
-        projectRoot: resolvePath(opts.path),
+        projectRoot: resolveTargetDirectory(opts),
         json: Boolean(opts.json),
         verbose: Boolean(opts.verbose),
         fast: Boolean(opts.fast)
@@ -160,11 +178,12 @@ async function main(): Promise<void> {
     .command('doctor')
     .description('Validate setup and detect configuration problems')
     .option('--path <dir>', 'Target project directory', process.cwd())
+    .option('-g, --global', 'Target global user home directory (~/.agents)', false)
     .option('--fix', 'Apply safe automatic fixes', false)
     .option('--fix-dry-run', 'Preview what --fix would change without applying it', false)
-    .action(async (opts: { path: string; fix: boolean; fixDryRun: boolean }) => {
+    .action(async (opts: { path: string; global: boolean; fix: boolean; fixDryRun: boolean }) => {
       await runDoctor({
-        projectRoot: resolvePath(opts.path),
+        projectRoot: resolveTargetDirectory(opts),
         fix: Boolean(opts.fix),
         fixDryRun: Boolean(opts.fixDryRun)
       })
@@ -174,11 +193,12 @@ async function main(): Promise<void> {
     .command('update')
     .description('Check for a newer CLI version')
     .option('--path <dir>', 'Project directory used for local update-check cache', process.cwd())
+    .option('-g, --global', 'Target global user home directory (~/.agents)', false)
     .option('--json', 'Output machine-readable JSON', false)
     .option('--check', 'Set exit code only (0 up-to-date, 10 outdated, 1 check failure)', false)
-    .action(async (opts: { path: string; json: boolean; check: boolean }) => {
+    .action(async (opts: { path: string; global: boolean; json: boolean; check: boolean }) => {
       await runUpdate({
-        projectRoot: resolvePath(opts.path),
+        projectRoot: resolveTargetDirectory(opts),
         json: Boolean(opts.json),
         check: Boolean(opts.check)
       })
@@ -188,11 +208,12 @@ async function main(): Promise<void> {
     .command('reset')
     .description('Clean generated/materialized files safely')
     .option('--path <dir>', 'Target project directory', process.cwd())
+    .option('-g, --global', 'Target global user home directory (~/.agents)', false)
     .option('--local-only', 'Clean only materialized integration files', false)
     .option('--hard', 'Remove all agents-managed setup (including .agents, root AGENTS.md, and managed CLAUDE.md)', false)
-    .action(async (opts: { path: string; localOnly: boolean; hard: boolean }) => {
+    .action(async (opts: { path: string; global: boolean; localOnly: boolean; hard: boolean }) => {
       await runReset({
-        projectRoot: resolvePath(opts.path),
+        projectRoot: resolveTargetDirectory(opts),
         localOnly: Boolean(opts.localOnly),
         hard: Boolean(opts.hard)
       })
@@ -204,10 +225,11 @@ async function main(): Promise<void> {
     .command('list')
     .description('List project MCP servers')
     .option('--path <dir>', 'Target project directory', process.cwd())
+    .option('-g, --global', 'Target global user home directory (~/.agents)', false)
     .option('--json', 'Output machine-readable JSON', false)
-    .action(async (opts: { path: string; json: boolean }) => {
+    .action(async (opts: { path: string; global: boolean; json: boolean }) => {
       await runMcpList({
-        projectRoot: resolvePath(opts.path),
+        projectRoot: resolveTargetDirectory(opts),
         json: Boolean(opts.json)
       })
     })
@@ -216,6 +238,7 @@ async function main(): Promise<void> {
     .command('add [name]')
     .description('Add a project MCP server (or auto-import when [name] is a URL)')
     .option('--path <dir>', 'Target project directory', process.cwd())
+    .option('-g, --global', 'Target global user home directory (~/.agents)', false)
     .option('--transport <type>', 'stdio|http|sse')
     .option('--command <cmd>', 'Command for stdio transport')
     .option('--arg <value>', 'Argument for stdio transport (repeatable)', collectOption, [])
@@ -234,6 +257,7 @@ async function main(): Promise<void> {
     .action(
       async (name: string | undefined, opts: {
         path: string
+        global: boolean
         transport?: string
         command?: string
         arg: string[]
@@ -251,7 +275,7 @@ async function main(): Promise<void> {
         nonInteractive: boolean
       }) => {
         await runMcpAdd({
-          projectRoot: resolvePath(opts.path),
+          projectRoot: resolveTargetDirectory(opts),
           name,
           transport: opts.transport,
           command: opts.command,
@@ -276,6 +300,7 @@ async function main(): Promise<void> {
     .command('import')
     .description('Import MCP server definitions from JSON/JSONC or URL')
     .option('--path <dir>', 'Target project directory', process.cwd())
+    .option('-g, --global', 'Target global user home directory (~/.agents)', false)
     .option('--file <path>', 'Load JSON/JSONC payload from file')
     .option('--json <text>', 'Inline JSON/JSONC payload')
     .option('--url <url>', 'Load MCP payload from URL (extract JSON snippet)')
@@ -287,6 +312,7 @@ async function main(): Promise<void> {
     .action(
       async (opts: {
         path: string
+        global: boolean
         file?: string
         json?: string
         url?: string
@@ -297,7 +323,7 @@ async function main(): Promise<void> {
         nonInteractive: boolean
       }) => {
         await runMcpImport({
-          projectRoot: resolvePath(opts.path),
+          projectRoot: resolveTargetDirectory(opts),
           file: opts.file,
           json: opts.json,
           url: opts.url,
@@ -314,11 +340,12 @@ async function main(): Promise<void> {
     .command('remove <name>')
     .description('Remove a project MCP server')
     .option('--path <dir>', 'Target project directory', process.cwd())
+    .option('-g, --global', 'Target global user home directory (~/.agents)', false)
     .option('--ignore-missing', 'Do not fail if server does not exist', false)
     .option('--no-sync', 'Skip automatic sync after update')
-    .action(async (name: string, opts: { path: string; ignoreMissing: boolean; sync: boolean }) => {
+    .action(async (name: string, opts: { path: string; global: boolean; ignoreMissing: boolean; sync: boolean }) => {
       await runMcpRemove({
-        projectRoot: resolvePath(opts.path),
+        projectRoot: resolveTargetDirectory(opts),
         name,
         ignoreMissing: Boolean(opts.ignoreMissing),
         noSync: opts.sync === false
@@ -329,12 +356,13 @@ async function main(): Promise<void> {
     .command('test [name]')
     .description('Validate MCP server definitions')
     .option('--path <dir>', 'Target project directory', process.cwd())
+    .option('-g, --global', 'Target global user home directory (~/.agents)', false)
     .option('--json', 'Output machine-readable JSON', false)
     .option('--runtime', 'Run runtime health checks via integration CLIs (best-effort)', false)
     .option('--runtime-timeout-ms <ms>', 'Timeout for each runtime CLI probe', '8000')
-    .action(async (name: string | undefined, opts: { path: string; json: boolean; runtime: boolean; runtimeTimeoutMs: string }) => {
+    .action(async (name: string | undefined, opts: { path: string; global: boolean; json: boolean; runtime: boolean; runtimeTimeoutMs: string }) => {
       await runMcpTest({
-        projectRoot: resolvePath(opts.path),
+        projectRoot: resolveTargetDirectory(opts),
         name,
         json: Boolean(opts.json),
         runtime: Boolean(opts.runtime),
@@ -346,12 +374,13 @@ async function main(): Promise<void> {
     .command('doctor [name]')
     .description('Alias for "agents mcp test"')
     .option('--path <dir>', 'Target project directory', process.cwd())
+    .option('-g, --global', 'Target global user home directory (~/.agents)', false)
     .option('--json', 'Output machine-readable JSON', false)
     .option('--runtime', 'Run runtime health checks via integration CLIs (best-effort)', false)
     .option('--runtime-timeout-ms <ms>', 'Timeout for each runtime CLI probe', '8000')
-    .action(async (name: string | undefined, opts: { path: string; json: boolean; runtime: boolean; runtimeTimeoutMs: string }) => {
+    .action(async (name: string | undefined, opts: { path: string; global: boolean; json: boolean; runtime: boolean; runtimeTimeoutMs: string }) => {
       await runMcpTest({
-        projectRoot: resolvePath(opts.path),
+        projectRoot: resolveTargetDirectory(opts),
         name,
         json: Boolean(opts.json),
         runtime: Boolean(opts.runtime),

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -15,6 +15,7 @@ import { runStatus } from './commands/status.js'
 import { runSync } from './commands/sync.js'
 import { runUpdate } from './commands/update.js'
 import { runWatch } from './commands/watch.js'
+import { runSkillsList } from './commands/skills-list.js'
 import { CancelledError } from './core/errors.js'
 import { maybeNotifyAboutUpdate } from './core/updateCheck.js'
 import { CLI_VERSION } from './core/version.js'
@@ -385,6 +386,22 @@ async function main(): Promise<void> {
         json: Boolean(opts.json),
         runtime: Boolean(opts.runtime),
         runtimeTimeoutMs: Number.parseInt(opts.runtimeTimeoutMs, 10)
+      })
+    })
+
+  const skills = program.command('skills').description('Manage and inspect skills in .agents/skills')
+
+  skills
+    .command('list')
+    .alias('ls')
+    .description('List configured skills')
+    .option('--path <dir>', 'Target project directory', process.cwd())
+    .option('-g, --global', 'Target global user home directory (~/.agents)', false)
+    .option('--json', 'Output machine-readable JSON', false)
+    .action(async (opts: { path: string; global: boolean; json: boolean }) => {
+      await runSkillsList({
+        projectRoot: resolveTargetDirectory(opts),
+        json: Boolean(opts.json)
       })
     })
 

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -1,3 +1,4 @@
+import path from 'node:path'
 import TOML from '@iarna/toml'
 import { loadAgentsConfig } from '../core/config.js'
 import { getClaudeInstructionsHealth } from '../core/claudeInstructions.js'
@@ -7,7 +8,7 @@ import {
 } from '../core/claudeDesktop.js'
 import { pathExists, readJson, readTextOrEmpty } from '../core/fs.js'
 import { loadResolvedRegistry } from '../core/mcp.js'
-import { getProjectPaths } from '../core/paths.js'
+import { getProjectPaths, toHomeRelativePath } from '../core/paths.js'
 import type { ProjectPaths } from '../core/paths.js'
 import { getWindsurfGlobalMcpPath } from '../core/windsurf.js'
 import { commandExists, runCommand } from '../core/shell.js'
@@ -216,7 +217,7 @@ export async function runDoctor(options: DoctorOptions): Promise<void> {
         ...(enabled.has('gemini') ? ['.gemini/skills'] : []),
         ...(enabled.has('junie') ? ['.junie/mcp/mcp.json', '.junie/skills'] : []),
         ...(enabled.has('antigravity') ? ['.agents/mcp_config.json'] : []),
-        ...(enabled.has('opencode') ? ['opencode.json'] : [])
+        ...(enabled.has('opencode') ? [paths.isHome ? '.config/opencode/opencode.json' : 'opencode.json'] : [])
       ]
     : []
   trackedChecks.push('.agents/generated', '.agents/local.json')
@@ -324,9 +325,17 @@ export async function runDoctor(options: DoctorOptions): Promise<void> {
   }
 
   if (enabled.has('opencode') && !(await pathExists(paths.opencodeConfig)) && !applyFixes) {
+    const opencodeLabel = paths.isHome ? toHomeRelativePath(paths.opencodeConfig) : 'opencode.json'
     issues.push({
       level: 'warning',
-      message: 'OpenCode config missing: opencode.json (run agents sync).'
+      message: `OpenCode config missing: ${opencodeLabel} (run agents sync).`
+    })
+  }
+
+  if (paths.isHome && (await pathExists(path.join(paths.root, 'opencode.json')))) {
+    issues.push({
+      level: 'warning',
+      message: 'Found opencode.json in home directory (~/opencode.json). In global mode, OpenCode uses ~/.config/opencode/opencode.json.'
     })
   }
 
@@ -646,7 +655,8 @@ async function validateManagedConfigSyntax(
     )
   }
   if (enabledIntegrations.includes('opencode')) {
-    await validateJsonIfExists(paths.opencodeConfig, 'opencode.json', issues)
+    const opencodeLabel = paths.isHome ? toHomeRelativePath(paths.opencodeConfig) : 'opencode.json'
+    await validateJsonIfExists(paths.opencodeConfig, opencodeLabel, issues)
   }
   if (enabledIntegrations.includes('junie')) {
     await validateJsonIfExists(paths.junieMcp, '.junie/mcp/mcp.json', issues)

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -217,7 +217,9 @@ export async function runDoctor(options: DoctorOptions): Promise<void> {
         ...(enabled.has('gemini') ? ['.gemini/skills'] : []),
         ...(enabled.has('junie') ? ['.junie/mcp/mcp.json', '.junie/skills'] : []),
         ...(enabled.has('antigravity') ? ['.agents/mcp_config.json'] : []),
-        ...(enabled.has('opencode') ? [paths.isHome ? '.config/opencode/opencode.json' : 'opencode.json'] : [])
+        ...(enabled.has('opencode') && !path.relative(options.projectRoot, paths.opencodeConfig).startsWith('..') && !path.isAbsolute(path.relative(options.projectRoot, paths.opencodeConfig))
+          ? [path.relative(options.projectRoot, paths.opencodeConfig)]
+          : [])
       ]
     : []
   trackedChecks.push('.agents/generated', '.agents/local.json')

--- a/src/commands/skills-list.ts
+++ b/src/commands/skills-list.ts
@@ -1,0 +1,93 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
+import { getProjectPaths } from '../core/paths.js'
+import { discoverSkills } from '../core/skillsDiscovery.js'
+import * as ui from '../core/ui.js'
+
+export interface SkillsListOptions {
+  projectRoot: string
+  json: boolean
+}
+
+export interface SkillListItem {
+  name: string
+  path: string
+  description: string
+}
+
+/**
+ * List all discovered skills in .agents/skills with their relative paths and descriptions.
+ *
+ * @param options - Options controlling skill listing output (projectRoot, json)
+ */
+export async function runSkillsList(options: SkillsListOptions): Promise<void> {
+  ui.setContext({ json: options.json })
+  const paths = getProjectPaths(options.projectRoot)
+  const discovery = await discoverSkills(paths.agentsSkillsDir)
+
+  const items: SkillListItem[] = []
+  for (const skill of discovery.skills) {
+    let description = ''
+    try {
+      const content = await readFile(skill.skillFilePath, 'utf8')
+      const match = content.match(/^---\s*\n([\s\S]*?)\n---\s*\n?/u)
+      if (match) {
+        for (const line of match[1].split('\n')) {
+          const trimmed = line.trim()
+          if (trimmed.startsWith('description:')) {
+            description = trimmed.slice('description:'.length).trim().replace(/^["']|["']$/g, '')
+            break
+          }
+        }
+      }
+    } catch {
+      // ignore read error
+    }
+
+    items.push({
+      name: skill.name,
+      path: skill.relativePath,
+      description
+    })
+  }
+
+  const payload = {
+    projectRoot: path.resolve(options.projectRoot),
+    skillsDir: paths.agentsSkillsDir,
+    count: items.length,
+    skills: items,
+    duplicates: discovery.duplicates
+  }
+
+  if (options.json) {
+    ui.json(payload)
+    return
+  }
+
+  ui.keyValue('Project', payload.projectRoot)
+  ui.keyValue('Skills dir', paths.agentsSkillsDir)
+  ui.keyValue('Skills', String(payload.count))
+
+  if (payload.count === 0) {
+    ui.blank()
+    ui.dim('No skills configured in .agents/skills.')
+    return
+  }
+
+  ui.blank()
+  for (const item of payload.skills) {
+    const symbol = ui.color.green(ui.symbols.success)
+    const pathSuffix = item.path !== item.name ? ` ${ui.color.dim(`(${item.path})`)}` : ''
+    ui.writeln(`  ${symbol} ${ui.color.bold(item.name)}${pathSuffix}`)
+    if (item.description) {
+      ui.writeln(`      ${ui.color.dim(item.description)}`)
+    }
+  }
+
+  if (discovery.duplicates.length > 0) {
+    ui.blank()
+    for (const dup of discovery.duplicates) {
+      ui.warning(`Duplicate skill name "${dup.name}" found in: ${dup.relativePaths.join(', ')}`)
+    }
+  }
+}

--- a/src/commands/skills-list.ts
+++ b/src/commands/skills-list.ts
@@ -2,6 +2,7 @@ import path from 'node:path'
 import { readFile } from 'node:fs/promises'
 import { getProjectPaths } from '../core/paths.js'
 import { discoverSkills } from '../core/skillsDiscovery.js'
+import { sanitizeTerminalOutput } from '../core/cursorCli.js'
 import * as ui from '../core/ui.js'
 
 export interface SkillsListOptions {
@@ -77,10 +78,12 @@ export async function runSkillsList(options: SkillsListOptions): Promise<void> {
   ui.blank()
   for (const item of payload.skills) {
     const symbol = ui.color.green(ui.symbols.success)
-    const pathSuffix = item.path !== item.name ? ` ${ui.color.dim(`(${item.path})`)}` : ''
-    ui.writeln(`  ${symbol} ${ui.color.bold(item.name)}${pathSuffix}`)
+    const sanitizedName = sanitizeTerminalOutput(item.name)
+    const sanitizedPath = sanitizeTerminalOutput(item.path)
+    const pathSuffix = sanitizedPath !== sanitizedName ? ` ${ui.color.dim(`(${sanitizedPath})`)}` : ''
+    ui.writeln(`  ${symbol} ${ui.color.bold(sanitizedName)}${pathSuffix}`)
     if (item.description) {
-      ui.writeln(`      ${ui.color.dim(item.description)}`)
+      ui.writeln(`      ${ui.color.dim(sanitizeTerminalOutput(item.description))}`)
     }
   }
 

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -11,7 +11,7 @@ import { commandExists } from '../core/shell.js'
 import { syncProjectDocsSections } from '../core/projectDocs.js'
 import type { AgentsConfig, IntegrationName, SyncMode } from '../types.js'
 import { INTEGRATIONS } from '../integrations/registry.js'
-import { getProjectPaths } from '../core/paths.js'
+import { getProjectPaths, toHomeRelativePath } from '../core/paths.js'
 import { runReset } from './reset.js'
 import { ensureCodexProjectTrusted, getCodexTrustState } from '../core/trust.js'
 import { formatWarnings, normalizeWarnings } from '../core/warnings.js'
@@ -244,6 +244,7 @@ async function resolveIntegrationAccess(args: {
   warnings: string[]
 }> {
   const { projectRoot, selectedIntegrations, interactive, autoApprove, integrationOptions: baseOptions, allowOptionPrompts } = args
+  const paths = getProjectPaths(projectRoot)
 
   const summaries: Record<string, string> = {}
   const warnings: string[] = []
@@ -336,7 +337,7 @@ async function resolveIntegrationAccess(args: {
   }
 
   if (selectedIntegrations.includes('opencode')) {
-    summaries.opencode = 'project opencode.json'
+    summaries.opencode = paths.isHome ? `global ${toHomeRelativePath(paths.opencodeConfig)}` : 'project opencode.json'
   }
 
   if (selectedIntegrations.includes('junie')) {

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -83,6 +83,7 @@ export async function runStatus(options: StatusOptions): Promise<void> {
   const expectedWindsurfServers = resolved.serversByTarget.windsurf.map((server) => server.name)
   const expectedOpencodeServers = resolved.serversByTarget.opencode.map((server) => server.name)
   const expectedJunieServers = resolved.serversByTarget.junie.map((server) => server.name)
+  const opencodeConfigLabel = paths.isHome ? toHomeRelativePath(paths.opencodeConfig) : 'opencode.json'
 
   const files: Record<string, boolean> = {
     '.agents/agents.json': await pathExists(paths.agentsConfig),
@@ -119,8 +120,7 @@ export async function runStatus(options: StatusOptions): Promise<void> {
     files[windsurfGlobalLabel] = await pathExists(windsurfGlobalPath)
   }
   if (enabled.has('opencode')) {
-    const opencodeLabel = paths.isHome ? toHomeRelativePath(paths.opencodeConfig) : 'opencode.json'
-    files[opencodeLabel] = await pathExists(paths.opencodeConfig)
+    files[opencodeConfigLabel] = await pathExists(paths.opencodeConfig)
   }
   if (enabled.has('junie')) {
     files['.junie/mcp/mcp.json'] = await pathExists(paths.junieMcp)
@@ -171,7 +171,7 @@ export async function runStatus(options: StatusOptions): Promise<void> {
       probes.windsurf = await probeWindsurf(windsurfGlobalPath, windsurfGlobalLabel, expectedWindsurfServers)
     }
     if (enabled.has('opencode')) {
-      probes.opencode = await probeOpencode(paths.opencodeConfig, expectedOpencodeServers)
+      probes.opencode = await probeOpencode(paths.opencodeConfig, expectedOpencodeServers, opencodeConfigLabel)
     }
     if (enabled.has('junie')) {
       probes.junie = await probeMcpServersFile(paths.junieMcp, '.junie/mcp/mcp.json', 'mcpServers', expectedJunieServers)
@@ -438,8 +438,9 @@ async function probeClaudeDesktop(
   }
 }
 
-async function probeOpencode(configPath: string, expectedServerNames: string[]): Promise<string> {
-  if (!(await pathExists(configPath))) return 'missing opencode.json'
+/** Probe the OpenCode configuration and verify expected MCP servers. */
+async function probeOpencode(configPath: string, expectedServerNames: string[], label = 'opencode.json'): Promise<string> {
+  if (!(await pathExists(configPath))) return `missing ${label}`
   try {
     const parsed = await readJson<{ mcp?: Record<string, unknown> }>(configPath)
     const names = Object.keys(parsed.mcp ?? {})
@@ -449,7 +450,7 @@ async function probeOpencode(configPath: string, expectedServerNames: string[]):
     }
     return `${names.length} server(s) configured`
   } catch {
-    return 'invalid opencode.json'
+    return `invalid ${label}`
   }
 }
 

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -5,7 +5,7 @@ import { parse, type ParseError } from 'jsonc-parser'
 import { loadAgentsConfig } from '../core/config.js'
 import { listDirNames, pathExists, readJson } from '../core/fs.js'
 import { loadResolvedRegistry } from '../core/mcp.js'
-import { getProjectPaths } from '../core/paths.js'
+import { getProjectPaths, toHomeRelativePath } from '../core/paths.js'
 import {
   getClaudeDesktopConfigPath,
   getClaudeDesktopConfigUnavailableDetail,
@@ -119,7 +119,8 @@ export async function runStatus(options: StatusOptions): Promise<void> {
     files[windsurfGlobalLabel] = await pathExists(windsurfGlobalPath)
   }
   if (enabled.has('opencode')) {
-    files['opencode.json'] = await pathExists(paths.opencodeConfig)
+    const opencodeLabel = paths.isHome ? toHomeRelativePath(paths.opencodeConfig) : 'opencode.json'
+    files[opencodeLabel] = await pathExists(paths.opencodeConfig)
   }
   if (enabled.has('junie')) {
     files['.junie/mcp/mcp.json'] = await pathExists(paths.junieMcp)
@@ -512,12 +513,4 @@ function extractCodexServerNames(entries: Array<Record<string, unknown>>): strin
     }
   }
   return [...new Set(names)].sort((a, b) => a.localeCompare(b))
-}
-
-function toHomeRelativePath(filePath: string): string {
-  const home = os.homedir()
-  const relative = path.relative(home, filePath)
-  if (relative.length === 0) return '~'
-  if (relative.startsWith('..') || path.isAbsolute(relative)) return filePath
-  return path.join('~', relative)
 }

--- a/src/core/opencode.ts
+++ b/src/core/opencode.ts
@@ -1,5 +1,11 @@
 import path from 'node:path'
 import { ensureDir, pathExists, readJson, writeJsonAtomic } from './fs.js'
+export {
+  getOpencodeConfigPath,
+  getOpencodeDir,
+  getOpencodeGlobalConfigDir,
+  getOpencodeGlobalConfigPath
+} from './paths.js'
 
 export interface OpencodeConfig {
   mcp?: Record<string, unknown>

--- a/src/core/opencode.ts
+++ b/src/core/opencode.ts
@@ -12,6 +12,7 @@ export interface OpencodeConfig {
   [key: string]: unknown
 }
 
+/** Read and parse an OpenCode configuration file as an OpencodeConfig object. */
 export async function readOpencodeConfig(configPath: string): Promise<OpencodeConfig> {
   if (!(await pathExists(configPath))) {
     return {}
@@ -19,11 +20,13 @@ export async function readOpencodeConfig(configPath: string): Promise<OpencodeCo
   return readJson<OpencodeConfig>(configPath)
 }
 
+/** Atomically write an OpenCode configuration object to disk after normalization. */
 export async function writeOpencodeConfig(configPath: string, config: OpencodeConfig): Promise<void> {
   await ensureDir(path.dirname(configPath))
   await writeJsonAtomic(configPath, normalizeOpencodeConfig(config))
 }
 
+/** Normalize an OpenCode configuration ensuring the mcp container is a valid record. */
 export function normalizeOpencodeConfig(config: OpencodeConfig): OpencodeConfig {
   return {
     ...config,

--- a/src/core/paths.ts
+++ b/src/core/paths.ts
@@ -1,7 +1,9 @@
+import os from 'node:os'
 import path from 'node:path'
 
 export interface ProjectPaths {
   root: string
+  isHome: boolean
   agentsDir: string
   agentsConfig: string
   agentsLocal: string
@@ -57,6 +59,83 @@ export interface ProjectPaths {
   windsurfSkillsBridge: string
 }
 
+/** Resolve the effective user home directory, honoring AGENTS_HOME_DIR in test/override environments. */
+export function getHomeDir(): string {
+  const override = process.env.AGENTS_HOME_DIR
+  if (override && override.trim().length > 0) {
+    return path.resolve(override.trim())
+  }
+  return os.homedir()
+}
+
+/** Check whether a target path refers to the user's home directory. */
+export function isHomeDirectory(targetPath: string, homeDir = getHomeDir()): boolean {
+  const resolvedTarget = path.resolve(targetPath)
+  const resolvedHome = path.resolve(homeDir)
+  return process.platform === 'win32'
+    ? resolvedTarget.toLowerCase() === resolvedHome.toLowerCase()
+    : resolvedTarget === resolvedHome
+}
+
+/** Convert an absolute path to a home-relative display label (`~/...`) when inside the home directory. */
+export function toHomeRelativePath(filePath: string, homeDir = getHomeDir()): string {
+  const home = path.resolve(homeDir)
+  const relative = path.relative(home, filePath)
+  if (relative.length === 0) return '~'
+  if (relative.startsWith('..') || path.isAbsolute(relative)) return filePath
+  return path.join('~', relative)
+}
+
+/** Resolve OpenCode's global configuration directory (`~/.config/opencode` or `$XDG_CONFIG_HOME/opencode`). */
+export function getOpencodeGlobalConfigDir(homeDir = getHomeDir()): string {
+  const xdg = process.env.XDG_CONFIG_HOME
+  if (xdg && xdg.trim().length > 0) {
+    return path.join(path.resolve(xdg.trim()), 'opencode')
+  }
+  return path.join(path.resolve(homeDir), '.config', 'opencode')
+}
+
+/** Resolve OpenCode's global configuration file (`opencode.json`). */
+export function getOpencodeGlobalConfigPath(homeDir = getHomeDir()): string {
+  const override = process.env.AGENTS_OPENCODE_CONFIG_PATH
+  if (override && override.trim().length > 0) {
+    return path.resolve(override.trim())
+  }
+  return path.join(getOpencodeGlobalConfigDir(homeDir), 'opencode.json')
+}
+
+/**
+ * Resolve OpenCode configuration file path for a project or global home root.
+ *
+ * In project mode, resolves to `<projectRoot>/opencode.json`.
+ * In global mode (`projectRoot` is `$HOME`), resolves to `~/.config/opencode/opencode.json` (or `$XDG_CONFIG_HOME/opencode/opencode.json`).
+ */
+export function getOpencodeConfigPath(projectRoot: string, homeDir = getHomeDir()): string {
+  const override = process.env.AGENTS_OPENCODE_CONFIG_PATH
+  if (override && override.trim().length > 0) {
+    return path.resolve(override.trim())
+  }
+  const root = path.resolve(projectRoot)
+  if (isHomeDirectory(root, homeDir)) {
+    return getOpencodeGlobalConfigPath(homeDir)
+  }
+  return path.join(root, 'opencode.json')
+}
+
+/**
+ * Resolve OpenCode tool directory for a project or global home root.
+ *
+ * In project mode, resolves to `<projectRoot>/.opencode`.
+ * In global mode (`projectRoot` is `$HOME`), resolves to `~/.config/opencode` (or `$XDG_CONFIG_HOME/opencode`).
+ */
+export function getOpencodeDir(projectRoot: string, homeDir = getHomeDir()): string {
+  const root = path.resolve(projectRoot)
+  if (isHomeDirectory(root, homeDir)) {
+    return getOpencodeGlobalConfigDir(homeDir)
+  }
+  return path.join(root, '.opencode')
+}
+
 /**
  * Construct a complete set of filesystem paths for a project based on the given project root.
  *
@@ -65,11 +144,14 @@ export interface ProjectPaths {
  */
 export function getProjectPaths(projectRoot: string): ProjectPaths {
   const root = path.resolve(projectRoot)
+  const homeDir = getHomeDir()
+  const isHome = isHomeDirectory(root, homeDir)
   const agentsDir = path.join(root, '.agents')
   const generatedDir = path.join(agentsDir, 'generated')
 
   return {
     root,
+    isHome,
     agentsDir,
     agentsConfig: path.join(agentsDir, 'agents.json'),
     agentsLocal: path.join(agentsDir, 'local.json'),
@@ -105,14 +187,14 @@ export function getProjectPaths(projectRoot: string): ProjectPaths {
     cursorMcp: path.join(root, '.cursor', 'mcp.json'),
     antigravityWorkspaceMcp: path.join(agentsDir, 'mcp_config.json'),
     antigravityProjectMcp: path.join(root, '.antigravity', 'mcp.json'),
-    opencodeConfig: path.join(root, 'opencode.json'),
+    opencodeConfig: getOpencodeConfigPath(root, homeDir),
     codexDir: path.join(root, '.codex'),
     geminiDir: path.join(root, '.gemini'),
     vscodeDir: path.join(root, '.vscode'),
     cursorDir: path.join(root, '.cursor'),
     antigravityDir: path.join(root, '.antigravity'),
     windsurfDir: path.join(root, '.windsurf'),
-    opencodeDir: path.join(root, '.opencode'),
+    opencodeDir: getOpencodeDir(root, homeDir),
     claudeDir: path.join(root, '.claude'),
     generatedJunie: path.join(generatedDir, 'junie.mcp.json'),
     junieDir: path.join(root, '.junie'),

--- a/src/integrations/syncHooks.ts
+++ b/src/integrations/syncHooks.ts
@@ -287,17 +287,30 @@ export const INTEGRATION_SYNC_HOOKS: IntegrationSyncHook[] = [
       }
 
       let existing: Record<string, unknown> = {}
-      if (await pathExists(targetPath)) {
+      let sourcePath = targetPath
+      let migratedFromLegacy = false
+      if (!(await pathExists(targetPath)) && context.paths.isHome) {
+        const legacyPath = path.join(context.projectRoot, 'opencode.json')
+        if (await pathExists(legacyPath)) {
+          sourcePath = legacyPath
+          migratedFromLegacy = true
+        }
+      }
+
+      if (await pathExists(sourcePath)) {
         try {
-          const parsed = await readJson<unknown>(targetPath)
+          const parsed = await readJson<unknown>(sourcePath)
           if (!isRecord(parsed)) {
-            context.warnings.push(`Existing OpenCode config at ${targetPath} is not a JSON object; skipped OpenCode sync.`)
+            context.warnings.push(`Existing OpenCode config at ${sourcePath} is not a JSON object; skipped OpenCode sync.`)
             return
           }
           existing = parsed
+          if (migratedFromLegacy) {
+            context.warnings.push('Migrated existing OpenCode settings from legacy ~/opencode.json to ~/.config/opencode/opencode.json.')
+          }
         } catch (error) {
           context.warnings.push(
-            `Failed to read existing OpenCode config at ${targetPath}; skipped OpenCode sync. ${error instanceof Error ? error.message : String(error)}`,
+            `Failed to read existing OpenCode config at ${sourcePath}; skipped OpenCode sync. ${error instanceof Error ? error.message : String(error)}`,
           )
           return
         }

--- a/tests/all-providers-global.integration.test.ts
+++ b/tests/all-providers-global.integration.test.ts
@@ -1,0 +1,160 @@
+import os from 'node:os'
+import path from 'node:path'
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { runInit } from '../src/commands/init.js'
+import { runDoctor } from '../src/commands/doctor.js'
+import { runStatus } from '../src/commands/status.js'
+import { loadAgentsConfig, saveAgentsConfig } from '../src/core/config.js'
+import { pathExists } from '../src/core/fs.js'
+import { performSync } from '../src/core/sync.js'
+import { INTEGRATION_IDS } from '../src/integrations/registry.js'
+
+const tempDirs: string[] = []
+let previousHomeDir: string | undefined
+let previousClaudeDesktopPath: string | undefined
+let previousWindsurfPath: string | undefined
+
+beforeEach(() => {
+  previousHomeDir = process.env.AGENTS_HOME_DIR
+  previousClaudeDesktopPath = process.env.AGENTS_CLAUDE_DESKTOP_CONFIG_PATH
+  previousWindsurfPath = process.env.AGENTS_WINDSURF_MCP_PATH
+})
+
+afterEach(async () => {
+  if (previousHomeDir === undefined) {
+    delete process.env.AGENTS_HOME_DIR
+  } else {
+    process.env.AGENTS_HOME_DIR = previousHomeDir
+  }
+
+  if (previousClaudeDesktopPath === undefined) {
+    delete process.env.AGENTS_CLAUDE_DESKTOP_CONFIG_PATH
+  } else {
+    process.env.AGENTS_CLAUDE_DESKTOP_CONFIG_PATH = previousClaudeDesktopPath
+  }
+
+  if (previousWindsurfPath === undefined) {
+    delete process.env.AGENTS_WINDSURF_MCP_PATH
+  } else {
+    process.env.AGENTS_WINDSURF_MCP_PATH = previousWindsurfPath
+  }
+
+  for (const dir of tempDirs.splice(0, tempDirs.length)) {
+    await rm(dir, { recursive: true, force: true })
+  }
+})
+
+describe('all providers global sync compatibility', () => {
+  it('synchronizes all 11 supported integrations in global mode without conflicts', { timeout: 25000 }, async () => {
+    const fakeHome = await mkdtemp(path.join(os.tmpdir(), 'agents-all-providers-home-'))
+    tempDirs.push(fakeHome)
+    process.env.AGENTS_HOME_DIR = fakeHome
+
+    const claudeDesktopFile = path.join(fakeHome, 'claude_desktop_config.json')
+    const windsurfFile = path.join(fakeHome, 'windsurf_mcp.json')
+    process.env.AGENTS_CLAUDE_DESKTOP_CONFIG_PATH = claudeDesktopFile
+    process.env.AGENTS_WINDSURF_MCP_PATH = windsurfFile
+
+    // Initialize in global mode
+    await runInit({ projectRoot: fakeHome, force: true })
+
+    // Enable all 11 integrations
+    const config = await loadAgentsConfig(fakeHome)
+    config.integrations.enabled = [...INTEGRATION_IDS]
+    await saveAgentsConfig(fakeHome, config)
+
+    // Add a custom skill to verify skill bridge sync for all tools
+    const skillDir = path.join(fakeHome, '.agents', 'skills', 'my-global-skill')
+    await mkdir(skillDir, { recursive: true })
+    await writeFile(
+      path.join(skillDir, 'SKILL.md'),
+      '---\nname: my-global-skill\ndescription: A machine-wide skill\n---\nGlobal skill instructions\n',
+      'utf8'
+    )
+
+    // Run full sync in global mode
+    const syncResult = await performSync({
+      projectRoot: fakeHome,
+      check: false,
+      verbose: false
+    })
+
+    expect(syncResult.changed).toBeDefined()
+
+    // Check outputs for EVERY provider:
+    // 1. Codex
+    const codexConfig = path.join(fakeHome, '.codex', 'config.toml')
+    expect(await pathExists(codexConfig)).toBe(true)
+    const codexContent = await readFile(codexConfig, 'utf8')
+    expect(codexContent).toContain('BEGIN agents-sync managed MCP')
+
+    // 2. Claude Desktop
+    expect(await pathExists(claudeDesktopFile)).toBe(true)
+
+    // 3. Gemini CLI
+    const geminiConfig = path.join(fakeHome, '.gemini', 'settings.json')
+    expect(await pathExists(geminiConfig)).toBe(true)
+
+    // 4. Cursor
+    const cursorConfig = path.join(fakeHome, '.cursor', 'mcp.json')
+    expect(await pathExists(cursorConfig)).toBe(true)
+
+    // 5. Copilot VS Code
+    const vscodeMcp = path.join(fakeHome, '.vscode', 'mcp.json')
+    expect(await pathExists(vscodeMcp)).toBe(true)
+
+    // 6. Copilot CLI
+    const copilotCliMcp = path.join(fakeHome, '.mcp.json')
+    expect(await pathExists(copilotCliMcp)).toBe(true)
+
+    // 7. Antigravity
+    const antigravityMcp = path.join(fakeHome, '.agents', 'mcp_config.json')
+    expect(await pathExists(antigravityMcp)).toBe(true)
+    const antigravitySkills = path.join(fakeHome, '.gemini', 'skills', 'my-global-skill')
+    expect(await pathExists(antigravitySkills)).toBe(true)
+
+    // 8. Windsurf
+    expect(await pathExists(windsurfFile)).toBe(true)
+    const windsurfSkills = path.join(fakeHome, '.windsurf', 'skills')
+    expect(await pathExists(windsurfSkills)).toBe(true)
+
+    // 9. OpenCode
+    const opencodeConfig = path.join(fakeHome, '.config', 'opencode', 'opencode.json')
+    expect(await pathExists(opencodeConfig)).toBe(true)
+    expect(await pathExists(path.join(fakeHome, 'opencode.json'))).toBe(false)
+
+    // 10. Junie
+    const junieConfig = path.join(fakeHome, '.junie', 'mcp', 'mcp.json')
+    expect(await pathExists(junieConfig)).toBe(true)
+    const junieSkills = path.join(fakeHome, '.junie', 'skills')
+    expect(await pathExists(junieSkills)).toBe(true)
+
+    // 11. Claude Code
+    const claudeSkills = path.join(fakeHome, '.claude', 'skills')
+    expect(await pathExists(claudeSkills)).toBe(true)
+    const claudeMd = path.join(fakeHome, 'CLAUDE.md')
+    expect(await pathExists(claudeMd)).toBe(true)
+
+    // Status check in global mode
+    let statusOutput = ''
+    const origWrite = process.stdout.write.bind(process.stdout)
+    process.stdout.write = (chunk: unknown) => {
+      statusOutput += String(chunk)
+      return true
+    }
+    try {
+      await runStatus({ projectRoot: fakeHome, json: true, fast: true, verbose: false })
+    } finally {
+      process.stdout.write = origWrite
+    }
+    const statusJson = JSON.parse(statusOutput) as { files: Record<string, boolean> }
+    expect(statusJson.files['~/.config/opencode/opencode.json']).toBe(true)
+    expect(statusJson.files['.codex/config.toml']).toBe(true)
+    expect(statusJson.files['.cursor/mcp.json']).toBe(true)
+    expect(statusJson.files['.gemini/settings.json']).toBe(true)
+
+    // Doctor check in global mode
+    await runDoctor({ projectRoot: fakeHome, fix: false })
+  })
+})

--- a/tests/cli-global.integration.test.ts
+++ b/tests/cli-global.integration.test.ts
@@ -82,5 +82,13 @@ describe('CLI --global / -g flag integration', () => {
     })
     const mcpParsed = JSON.parse(mcpStdout) as { servers: Array<{ name: string }> }
     expect(mcpParsed.servers.map((s) => s.name)).toContain('filesystem')
+
+    // 5. Run skills list -g --json
+    const { stdout: skillsStdout } = await execFileAsync('npx', ['tsx', cliPath, 'skills', 'list', '-g', '--json'], {
+      cwd: randomWorkdir,
+      env
+    })
+    const skillsParsed = JSON.parse(skillsStdout) as { skills: Array<{ name: string }> }
+    expect(skillsParsed.skills.length).toBeGreaterThan(0)
   })
 })

--- a/tests/cli-global.integration.test.ts
+++ b/tests/cli-global.integration.test.ts
@@ -1,0 +1,86 @@
+import os from 'node:os'
+import path from 'node:path'
+import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { pathExists } from '../src/core/fs.js'
+
+const execFileAsync = promisify(execFile)
+const tempDirs: string[] = []
+let previousHomeDir: string | undefined
+
+beforeEach(() => {
+  previousHomeDir = process.env.AGENTS_HOME_DIR
+})
+
+afterEach(async () => {
+  if (previousHomeDir === undefined) {
+    delete process.env.AGENTS_HOME_DIR
+  } else {
+    process.env.AGENTS_HOME_DIR = previousHomeDir
+  }
+
+  for (const dir of tempDirs.splice(0, tempDirs.length)) {
+    await rm(dir, { recursive: true, force: true })
+  }
+})
+
+describe('CLI --global / -g flag integration', () => {
+  it('runs init, connect, sync and status using --global flag from arbitrary working directory', async () => {
+    const fakeHome = await mkdtemp(path.join(os.tmpdir(), 'agents-cli-home-'))
+    const randomWorkdir = await mkdtemp(path.join(os.tmpdir(), 'agents-cli-workdir-'))
+    tempDirs.push(fakeHome, randomWorkdir)
+
+    const cliPath = path.resolve('src/cli.ts')
+    const env = {
+      ...process.env,
+      AGENTS_HOME_DIR: fakeHome,
+      AGENTS_NO_UPDATE_CHECK: '1',
+      NO_COLOR: '1'
+    }
+
+    // 1. Run init --global from random directory
+    await execFileAsync('npx', ['tsx', cliPath, 'init', '--global', '--force'], {
+      cwd: randomWorkdir,
+      env
+    })
+
+    expect(await pathExists(path.join(fakeHome, '.agents', 'agents.json'))).toBe(true)
+    expect(await pathExists(path.join(randomWorkdir, '.agents'))).toBe(false)
+
+    // 2. Run connect --llm opencode -g from random directory
+    await execFileAsync('npx', ['tsx', cliPath, 'connect', '--llm', 'opencode', '-g'], {
+      cwd: randomWorkdir,
+      env
+    })
+
+    const opencodeGlobalPath = path.join(fakeHome, '.config', 'opencode', 'opencode.json')
+    expect(await pathExists(opencodeGlobalPath)).toBe(true)
+    expect(await pathExists(path.join(randomWorkdir, 'opencode.json'))).toBe(false)
+
+    // 3. Check status --global --json
+    const { stdout: statusStdout } = await execFileAsync('npx', ['tsx', cliPath, 'status', '--global', '--json'], {
+      cwd: randomWorkdir,
+      env
+    })
+
+    const statusParsed = JSON.parse(statusStdout) as {
+      projectRoot: string
+      enabledIntegrations: string[]
+      files: Record<string, boolean>
+    }
+
+    expect(statusParsed.projectRoot).toBe(fakeHome)
+    expect(statusParsed.enabledIntegrations).toContain('opencode')
+    expect(statusParsed.files['~/.config/opencode/opencode.json']).toBe(true)
+
+    // 4. Run mcp list -g --json
+    const { stdout: mcpStdout } = await execFileAsync('npx', ['tsx', cliPath, 'mcp', 'list', '-g', '--json'], {
+      cwd: randomWorkdir,
+      env
+    })
+    const mcpParsed = JSON.parse(mcpStdout) as { servers: Array<{ name: string }> }
+    expect(mcpParsed.servers.map((s) => s.name)).toContain('filesystem')
+  })
+})

--- a/tests/global-opencode.integration.test.ts
+++ b/tests/global-opencode.integration.test.ts
@@ -1,0 +1,234 @@
+import os from 'node:os'
+import path from 'node:path'
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { runInit } from '../src/commands/init.js'
+import { runDoctor } from '../src/commands/doctor.js'
+import { runReset } from '../src/commands/reset.js'
+import { loadAgentsConfig, saveAgentsConfig } from '../src/core/config.js'
+import { pathExists } from '../src/core/fs.js'
+import { performSync } from '../src/core/sync.js'
+import { getProjectPaths } from '../src/core/paths.js'
+
+const tempDirs: string[] = []
+let previousHomeDir: string | undefined
+let previousXdgConfigHome: string | undefined
+
+beforeEach(() => {
+  previousHomeDir = process.env.AGENTS_HOME_DIR
+  previousXdgConfigHome = process.env.XDG_CONFIG_HOME
+})
+
+afterEach(async () => {
+  if (previousHomeDir === undefined) {
+    delete process.env.AGENTS_HOME_DIR
+  } else {
+    process.env.AGENTS_HOME_DIR = previousHomeDir
+  }
+
+  if (previousXdgConfigHome === undefined) {
+    delete process.env.XDG_CONFIG_HOME
+  } else {
+    process.env.XDG_CONFIG_HOME = previousXdgConfigHome
+  }
+
+  for (const dir of tempDirs.splice(0, tempDirs.length)) {
+    await rm(dir, { recursive: true, force: true })
+  }
+})
+
+describe('global installation and OpenCode config sync', () => {
+  it('correctly resolves global paths when projectRoot is home directory', async () => {
+    const fakeHome = await mkdtemp(path.join(os.tmpdir(), 'agents-home-'))
+    tempDirs.push(fakeHome)
+    process.env.AGENTS_HOME_DIR = fakeHome
+
+    const paths = getProjectPaths(fakeHome)
+    expect(paths.isHome).toBe(true)
+    expect(paths.opencodeDir).toBe(path.join(fakeHome, '.config', 'opencode'))
+    expect(paths.opencodeConfig).toBe(path.join(fakeHome, '.config', 'opencode', 'opencode.json'))
+  })
+
+  it('respects XDG_CONFIG_HOME in global mode', async () => {
+    const fakeHome = await mkdtemp(path.join(os.tmpdir(), 'agents-home-'))
+    const fakeXdg = await mkdtemp(path.join(os.tmpdir(), 'agents-xdg-'))
+    tempDirs.push(fakeHome, fakeXdg)
+    process.env.AGENTS_HOME_DIR = fakeHome
+    process.env.XDG_CONFIG_HOME = fakeXdg
+
+    const paths = getProjectPaths(fakeHome)
+    expect(paths.isHome).toBe(true)
+    expect(paths.opencodeDir).toBe(path.join(fakeXdg, 'opencode'))
+    expect(paths.opencodeConfig).toBe(path.join(fakeXdg, 'opencode', 'opencode.json'))
+  })
+
+  it('materializes OpenCode config at ~/.config/opencode/opencode.json in global mode', async () => {
+    const fakeHome = await mkdtemp(path.join(os.tmpdir(), 'agents-home-'))
+    tempDirs.push(fakeHome)
+    process.env.AGENTS_HOME_DIR = fakeHome
+
+    await runInit({ projectRoot: fakeHome, force: true })
+
+    const config = await loadAgentsConfig(fakeHome)
+    config.integrations.enabled = ['opencode']
+    await saveAgentsConfig(fakeHome, config)
+
+    const syncResult = await performSync({
+      projectRoot: fakeHome,
+      check: false,
+      verbose: false
+    })
+
+    const expectedConfigPath = path.join(fakeHome, '.config', 'opencode', 'opencode.json')
+    expect(await pathExists(expectedConfigPath)).toBe(true)
+    expect(await pathExists(path.join(fakeHome, 'opencode.json'))).toBe(false)
+    expect(syncResult.changed).toContain(path.join('.config', 'opencode', 'opencode.json'))
+
+    const parsed = JSON.parse(await readFile(expectedConfigPath, 'utf8')) as {
+      mcp?: Record<string, unknown>
+    }
+    expect(parsed.mcp).toBeDefined()
+    expect(Object.keys(parsed.mcp ?? {})).toContain('filesystem')
+  })
+
+  it('preserves existing global OpenCode settings during sync', async () => {
+    const fakeHome = await mkdtemp(path.join(os.tmpdir(), 'agents-home-'))
+    tempDirs.push(fakeHome)
+    process.env.AGENTS_HOME_DIR = fakeHome
+
+    const configDir = path.join(fakeHome, '.config', 'opencode')
+    await mkdir(configDir, { recursive: true })
+    const configPath = path.join(configDir, 'opencode.json')
+    await writeFile(
+      configPath,
+      JSON.stringify({
+        theme: 'catppuccin',
+        default_agent: 'code-review',
+        mcp: {
+          personal: {
+            command: ['node', 'personal-mcp.js']
+          }
+        }
+      }, null, 2),
+      'utf8'
+    )
+
+    await runInit({ projectRoot: fakeHome, force: true })
+    const config = await loadAgentsConfig(fakeHome)
+    config.integrations.enabled = ['opencode']
+    await saveAgentsConfig(fakeHome, config)
+
+    await performSync({
+      projectRoot: fakeHome,
+      check: false,
+      verbose: false
+    })
+
+    const parsed = JSON.parse(await readFile(configPath, 'utf8')) as {
+      theme?: string
+      default_agent?: string
+      mcp?: Record<string, unknown>
+    }
+    expect(parsed.theme).toBe('catppuccin')
+    expect(parsed.default_agent).toBe('code-review')
+    expect(Object.keys(parsed.mcp ?? {})).toContain('filesystem')
+    expect(Object.keys(parsed.mcp ?? {})).not.toContain('personal')
+  })
+
+  it('migrates settings from legacy ~/opencode.json if global config does not exist yet', async () => {
+    const fakeHome = await mkdtemp(path.join(os.tmpdir(), 'agents-home-'))
+    tempDirs.push(fakeHome)
+    process.env.AGENTS_HOME_DIR = fakeHome
+
+    const legacyPath = path.join(fakeHome, 'opencode.json')
+    await writeFile(
+      legacyPath,
+      JSON.stringify({
+        theme: 'dracula',
+        custom_key: 'custom_value'
+      }, null, 2),
+      'utf8'
+    )
+
+    await runInit({ projectRoot: fakeHome, force: true })
+    const config = await loadAgentsConfig(fakeHome)
+    config.integrations.enabled = ['opencode']
+    await saveAgentsConfig(fakeHome, config)
+
+    const syncResult = await performSync({
+      projectRoot: fakeHome,
+      check: false,
+      verbose: false
+    })
+
+    expect(syncResult.warnings.some((w) => w.includes('Migrated existing OpenCode settings from legacy ~/opencode.json'))).toBe(true)
+
+    const newPath = path.join(fakeHome, '.config', 'opencode', 'opencode.json')
+    expect(await pathExists(newPath)).toBe(true)
+
+    const parsed = JSON.parse(await readFile(newPath, 'utf8')) as {
+      theme?: string
+      custom_key?: string
+      mcp?: Record<string, unknown>
+    }
+    expect(parsed.theme).toBe('dracula')
+    expect(parsed.custom_key).toBe('custom_value')
+    expect(parsed.mcp).toBeDefined()
+  })
+
+  it('warns about legacy ~/opencode.json in doctor', async () => {
+    const fakeHome = await mkdtemp(path.join(os.tmpdir(), 'agents-home-'))
+    tempDirs.push(fakeHome)
+    process.env.AGENTS_HOME_DIR = fakeHome
+
+    await runInit({ projectRoot: fakeHome, force: true })
+    const config = await loadAgentsConfig(fakeHome)
+    config.integrations.enabled = ['opencode']
+    await saveAgentsConfig(fakeHome, config)
+
+    await performSync({ projectRoot: fakeHome, check: false, verbose: false })
+
+    // Create legacy misplaced opencode.json in home
+    await writeFile(path.join(fakeHome, 'opencode.json'), '{}\n', 'utf8')
+
+    let output = ''
+    const originalStdoutWrite = process.stdout.write.bind(process.stdout)
+    process.stdout.write = (chunk: unknown) => {
+      output += String(chunk)
+      return true
+    }
+
+    try {
+      await runDoctor({ projectRoot: fakeHome, fix: false })
+    } finally {
+      process.stdout.write = originalStdoutWrite
+    }
+
+    expect(output).toContain('Found opencode.json in home directory (~/opencode.json)')
+  })
+
+  it('resets global OpenCode managed config while preserving manual settings', async () => {
+    const fakeHome = await mkdtemp(path.join(os.tmpdir(), 'agents-home-'))
+    tempDirs.push(fakeHome)
+    process.env.AGENTS_HOME_DIR = fakeHome
+
+    await runInit({ projectRoot: fakeHome, force: true })
+    const config = await loadAgentsConfig(fakeHome)
+    config.integrations.enabled = ['opencode']
+    await saveAgentsConfig(fakeHome, config)
+
+    await performSync({ projectRoot: fakeHome, check: false, verbose: false })
+
+    const configPath = path.join(fakeHome, '.config', 'opencode', 'opencode.json')
+    const current = JSON.parse(await readFile(configPath, 'utf8')) as Record<string, unknown>
+    current.user_setting = 'custom'
+    await writeFile(configPath, JSON.stringify(current, null, 2), 'utf8')
+
+    await runReset({ projectRoot: fakeHome, localOnly: false, hard: false })
+
+    expect(await pathExists(configPath)).toBe(true)
+    const afterReset = JSON.parse(await readFile(configPath, 'utf8')) as Record<string, unknown>
+    expect(afterReset.user_setting).toBe('custom')
+    expect(afterReset.mcp).toBeUndefined()
+  })
+})

--- a/tests/skills-list.test.ts
+++ b/tests/skills-list.test.ts
@@ -1,0 +1,83 @@
+import os from 'node:os'
+import path from 'node:path'
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { afterEach, describe, expect, it } from 'vitest'
+import { runSkillsList } from '../src/commands/skills-list.js'
+import { runInit } from '../src/commands/init.js'
+
+const tempDirs: string[] = []
+
+afterEach(async () => {
+  for (const dir of tempDirs.splice(0, tempDirs.length)) {
+    await rm(dir, { recursive: true, force: true })
+  }
+})
+
+describe('agents skills list command', () => {
+  it('lists discovered skills in JSON mode', async () => {
+    const projectRoot = await mkdtemp(path.join(os.tmpdir(), 'agents-skills-list-'))
+    tempDirs.push(projectRoot)
+
+    await runInit({ projectRoot, force: true })
+
+    const skillDirA = path.join(projectRoot, '.agents', 'skills', 'review-code')
+    await mkdir(skillDirA, { recursive: true })
+    await writeFile(
+      path.join(skillDirA, 'SKILL.md'),
+      '---\nname: review-code\ndescription: Review pull requests and code changes\n---\nWorkflow\n',
+      'utf8'
+    )
+
+    let output = ''
+    const origWrite = process.stdout.write.bind(process.stdout)
+    process.stdout.write = (chunk: unknown) => {
+      output += String(chunk)
+      return true
+    }
+
+    try {
+      await runSkillsList({ projectRoot, json: true })
+    } finally {
+      process.stdout.write = origWrite
+    }
+
+    const parsed = JSON.parse(output) as {
+      count: number
+      skills: Array<{ name: string; path: string; description: string }>
+    }
+
+    expect(parsed.count).toBeGreaterThanOrEqual(1)
+    const reviewSkill = parsed.skills.find((s) => s.name === 'review-code')
+    expect(reviewSkill).toBeDefined()
+    expect(reviewSkill?.description).toBe('Review pull requests and code changes')
+    expect(reviewSkill?.path).toBe('review-code')
+  })
+
+  it('handles empty skills directory gracefully in human-readable mode', async () => {
+    const projectRoot = await mkdtemp(path.join(os.tmpdir(), 'agents-skills-empty-'))
+    tempDirs.push(projectRoot)
+
+    await runInit({ projectRoot, force: true })
+
+    // Empty skills dir
+    const skillsDir = path.join(projectRoot, '.agents', 'skills')
+    await rm(skillsDir, { recursive: true, force: true })
+    await mkdir(skillsDir, { recursive: true })
+
+    let output = ''
+    const origWrite = process.stdout.write.bind(process.stdout)
+    process.stdout.write = (chunk: unknown) => {
+      output += String(chunk)
+      return true
+    }
+
+    try {
+      await runSkillsList({ projectRoot, json: false })
+    } finally {
+      process.stdout.write = origWrite
+    }
+
+    expect(output).toContain('Skills')
+    expect(output).toContain('No skills configured')
+  })
+})


### PR DESCRIPTION
## Summary

- Support global installation across all CLI commands via `--global` / `-g` and auto-detection in `$HOME`.
- Target OpenCode global configuration at `~/.config/opencode/opencode.json` (or `$XDG_CONFIG_HOME/opencode/opencode.json`), preserving non-MCP settings and migrating legacy `~/opencode.json`.
- Add `agents skills list` (alias `ls`) command to inspect configured skills, paths, and descriptions.
- Support tilde expansion (`~` and `~/...`) for CLI `--path` arguments.
- Update `@humanfs/node` to `0.16.8` to resolve Dependabot security advisory GHSA-p498-v437-472g.
- Bump version to `0.8.11` and update documentation.

## Validation

- `npm run build`
- `npm run lint`
- `npm test`
- `git diff --check`

Closes #26

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Новые возможности**
  - Добавлен глобальный режим CLI через `--global` / `-g` для управления MCP-серверами, навыками и конфигурацией OpenCode.
  - Добавлена команда `agents skills list` с псевдонимом `ls` и JSON-выводом.
  - Аргументы путей с `~` автоматически преобразуются в домашний каталог.
  - Глобальная синхронизация поддерживается всеми интеграциями.

- **Исправления**
  - Улучшена диагностика глобальной конфигурации OpenCode.
  - Добавлена миграция устаревшей конфигурации OpenCode.
  - Устранена уязвимость обхода пути при рекурсивном копировании.

- **Документация**
  - README дополнен описанием глобального режима, управления навыками и расположения конфигурации.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->